### PR TITLE
Fix wrong de-serialization of `Ke2Message`

### DIFF
--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -536,7 +536,7 @@ impl<G: Group, HashLen: ArrayLength<u8>> FromBytes for Ke2Message<G, HashLen> {
         )?;
 
         // Check the public key bytes
-        let server_e_pk = KeyPair::<CS::OprfGroup>::check_public_key(PublicKey::from_bytes(
+        let server_e_pk = KeyPair::<CS::KeGroup>::check_public_key(PublicKey::from_bytes(
             &unchecked_server_e_pk[..key_len],
         )?)?;
 


### PR DESCRIPTION
The wrong `Group` was used here during de-serialization. I wanted to add a test, but was unsure where to add it, any suggestions?