### PR TITLE
Bump `voprf` to v0.5.0-pre.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           - --features serde
         toolchain:
           - stable
-          - 1.57.0
+          - 1.60.0
     name: test
     steps:
       - name: Checkout sources
@@ -78,7 +78,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.57.0
+          - 1.60.0
     name: test simple_login command-line example
     steps:
       - name: install expect
@@ -101,7 +101,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.57.0
+          - 1.60.0
     name: test digital_locker command-line example
     steps:
       - name: install expect

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ license = "Apache-2.0 OR MIT"
 name = "opaque-ke"
 readme = "README.md"
 repository = "https://github.com/novifinancial/opaque-ke"
-rust-version = "1.57"
+rust-version = "1.60"
 version = "2.0.0"
 
 [features]
-curve25519 = ["curve25519-dalek"]
+curve25519 = ["curve25519-dalek/precomputed-tables"]
 default = ["ristretto255-voprf", "serde"]
 ristretto255 = ["curve25519-dalek", "voprf/ristretto255"]
 ristretto255-voprf = ["ristretto255", "voprf/ristretto255-ciphersuite"]
@@ -23,8 +23,9 @@ std = ["getrandom"]
 argon2 = { version = "0.4", default-features = false, features = [
   "alloc",
 ], optional = true }
-curve25519-dalek = { version = "=4.0.0-pre.5", default-features = false, features = [
+curve25519-dalek = { version = "=4.0.0-rc.1", default-features = false, features = [
   "rand_core",
+  "zeroize",
 ], optional = true }
 derive-where = { version = "1", features = ["zeroize-on-drop"] }
 digest = "0.10"
@@ -38,7 +39,7 @@ serde_ = { version = "1", package = "serde", default-features = false, features 
   "derive",
 ], optional = true }
 subtle = { version = "2.3", default-features = false }
-voprf = { version = "=0.5.0-pre.1", default-features = false, features = [
+voprf = { version = "=0.5.0-pre.2", default-features = false, features = [
   "danger",
 ] }
 zeroize = { version = "1.5", features = ["zeroize_derive"] }
@@ -52,14 +53,15 @@ chacha20poly1305 = "0.10"
 criterion = "0.4"
 hex = "0.4"
 json = "0.12"
-p256 = { version = "0.11", default-features = false, features = [
+p256 = { version = "0.12", default-features = false, features = [
   "hash2curve",
   "voprf",
 ] }
 proptest = "1"
 rand = "0.8"
 regex = "1"
-rustyline = "10"
+# MSRV
+rustyline = "10.1.1"
 scrypt = "0.10"
 serde_json = "1"
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ opaque-ke = "2"
 
 ### Minimum Supported Rust Version
 
-Rust **1.57** or higher.
+Rust **1.60** or higher.
 
 Audit
 -----

--- a/benches/opaque.rs
+++ b/benches/opaque.rs
@@ -38,7 +38,7 @@ impl CipherSuite for Default {
 fn server_setup(c: &mut Criterion) {
     let mut rng = OsRng;
 
-    c.bench_function(&format!("server setup ({})", SUFFIX), move |b| {
+    c.bench_function(&format!("server setup ({SUFFIX})"), move |b| {
         b.iter(|| {
             ServerSetup::<Default>::new(&mut rng);
         })
@@ -49,14 +49,11 @@ fn client_registration_start(c: &mut Criterion) {
     let mut rng = OsRng;
     let password = b"password";
 
-    c.bench_function(
-        &format!("client registration start ({})", SUFFIX),
-        move |b| {
-            b.iter(|| {
-                ClientRegistration::<Default>::start(&mut rng, password).unwrap();
-            })
-        },
-    );
+    c.bench_function(&format!("client registration start ({SUFFIX})"), move |b| {
+        b.iter(|| {
+            ClientRegistration::<Default>::start(&mut rng, password).unwrap();
+        })
+    });
 }
 
 fn server_registration_start(c: &mut Criterion) {
@@ -67,19 +64,16 @@ fn server_registration_start(c: &mut Criterion) {
     let client_registration_start_result =
         ClientRegistration::<Default>::start(&mut rng, password).unwrap();
 
-    c.bench_function(
-        &format!("server registration start ({})", SUFFIX),
-        move |b| {
-            b.iter(|| {
-                ServerRegistration::<Default>::start(
-                    &server_setup,
-                    client_registration_start_result.message.clone(),
-                    username,
-                )
-                .unwrap();
-            })
-        },
-    );
+    c.bench_function(&format!("server registration start ({SUFFIX})"), move |b| {
+        b.iter(|| {
+            ServerRegistration::<Default>::start(
+                &server_setup,
+                client_registration_start_result.message.clone(),
+                username,
+            )
+            .unwrap();
+        })
+    });
 }
 
 fn client_registration_finish(c: &mut Criterion) {
@@ -97,7 +91,7 @@ fn client_registration_finish(c: &mut Criterion) {
     .unwrap();
 
     c.bench_function(
-        &format!("client registration finish ({})", SUFFIX),
+        &format!("client registration finish ({SUFFIX})"),
         move |b| {
             b.iter(|| {
                 client_registration_start_result
@@ -139,7 +133,7 @@ fn server_registration_finish(c: &mut Criterion) {
         .unwrap();
 
     c.bench_function(
-        &format!("server registration finish ({})", SUFFIX),
+        &format!("server registration finish ({SUFFIX})"),
         move |b| {
             b.iter(|| {
                 ServerRegistration::finish(client_registration_finish_result.clone().message);
@@ -152,7 +146,7 @@ fn client_login_start(c: &mut Criterion) {
     let mut rng = OsRng;
     let password = b"password";
 
-    c.bench_function(&format!("client login start ({})", SUFFIX), move |b| {
+    c.bench_function(&format!("client login start ({SUFFIX})"), move |b| {
         b.iter(|| {
             ClientLogin::<Default>::start(&mut rng, password).unwrap();
         })
@@ -184,22 +178,19 @@ fn server_login_start_real(c: &mut Criterion) {
     let password_file = ServerRegistration::finish(client_registration_finish_result.message);
     let client_login_start_result = ClientLogin::<Default>::start(&mut rng, password).unwrap();
 
-    c.bench_function(
-        &format!("server login start (real) ({})", SUFFIX),
-        move |b| {
-            b.iter(|| {
-                ServerLogin::start(
-                    &mut rng,
-                    &server_setup,
-                    Some(password_file.clone()),
-                    client_login_start_result.clone().message,
-                    username,
-                    ServerLoginStartParameters::default(),
-                )
-                .unwrap();
-            })
-        },
-    );
+    c.bench_function(&format!("server login start (real) ({SUFFIX})"), move |b| {
+        b.iter(|| {
+            ServerLogin::start(
+                &mut rng,
+                &server_setup,
+                Some(password_file.clone()),
+                client_login_start_result.clone().message,
+                username,
+                ServerLoginStartParameters::default(),
+            )
+            .unwrap();
+        })
+    });
 }
 
 fn server_login_start_fake(c: &mut Criterion) {
@@ -209,22 +200,19 @@ fn server_login_start_fake(c: &mut Criterion) {
     let server_setup = ServerSetup::<Default>::new(&mut rng);
     let client_login_start_result = ClientLogin::<Default>::start(&mut rng, password).unwrap();
 
-    c.bench_function(
-        &format!("server login start (fake) ({})", SUFFIX),
-        move |b| {
-            b.iter(|| {
-                ServerLogin::start(
-                    &mut rng,
-                    &server_setup,
-                    None,
-                    client_login_start_result.clone().message,
-                    username,
-                    ServerLoginStartParameters::default(),
-                )
-                .unwrap();
-            })
-        },
-    );
+    c.bench_function(&format!("server login start (fake) ({SUFFIX})"), move |b| {
+        b.iter(|| {
+            ServerLogin::start(
+                &mut rng,
+                &server_setup,
+                None,
+                client_login_start_result.clone().message,
+                username,
+                ServerLoginStartParameters::default(),
+            )
+            .unwrap();
+        })
+    });
 }
 
 fn client_login_finish(c: &mut Criterion) {
@@ -261,7 +249,7 @@ fn client_login_finish(c: &mut Criterion) {
     )
     .unwrap();
 
-    c.bench_function(&format!("client login finish ({})", SUFFIX), move |b| {
+    c.bench_function(&format!("client login finish ({SUFFIX})"), move |b| {
         b.iter(|| {
             client_login_start_result
                 .clone()
@@ -318,7 +306,7 @@ fn server_login_finish(c: &mut Criterion) {
         )
         .unwrap();
 
-    c.bench_function(&format!("server login finish ({})", SUFFIX), move |b| {
+    c.bench_function(&format!("server login finish ({SUFFIX})"), move |b| {
         b.iter(|| {
             server_login_start_result
                 .clone()

--- a/examples/digital_locker.rs
+++ b/examples/digital_locker.rs
@@ -275,13 +275,10 @@ fn main() {
                             &registered_lockers[locker_index],
                         ) {
                             Ok(contents) => {
-                                println!("\n\nSuccess! Contents: {}\n\n", contents);
+                                println!("\n\nSuccess! Contents: {contents}\n\n");
                             }
                             Err(err) => {
-                                println!(
-                                    "\n\nError encountered, could not open locker: {}\n\n",
-                                    err
-                                );
+                                println!("\n\nError encountered, could not open locker: {err}\n\n");
                             }
                         }
                     }
@@ -304,10 +301,7 @@ fn display_lockers(lockers: &[Locker]) {
         locker_numbers.push(i);
     }
 
-    println!(
-        "\nCurrently registered locker numbers: {:?}\n",
-        locker_numbers
-    );
+    println!("\nCurrently registered locker numbers: {locker_numbers:?}\n");
 }
 
 // Handle readline errors
@@ -320,7 +314,7 @@ fn handle_error(err: ReadlineError) {
             println!("CTRL-D");
         }
         err => {
-            println!("Error: {:?}", err);
+            println!("Error: {err:?}");
         }
     }
 }
@@ -333,7 +327,7 @@ fn get_two_strings(
     string1: Option<String>,
 ) -> (String, String) {
     let query = if string1.is_none() { s1 } else { s2 };
-    let readline = rl.readline(&format!("{}: ", query));
+    let readline = rl.readline(&format!("{query}: "));
     match readline {
         Ok(line) => match string1 {
             Some(x) => (x, line),

--- a/examples/simple_login.rs
+++ b/examples/simple_login.rs
@@ -228,7 +228,7 @@ fn handle_error(err: ReadlineError) {
             println!("CTRL-D");
         }
         err => {
-            println!("Error: {:?}", err);
+            println!("Error: {err:?}");
         }
     }
 }
@@ -241,7 +241,7 @@ fn get_two_strings(
     string1: Option<String>,
 ) -> (String, String) {
     let query = if string1.is_none() { s1 } else { s2 };
-    let readline = rl.readline(&format!("{}: ", query));
+    let readline = rl.readline(&format!("{query}: "));
     match readline {
         Ok(line) => match string1 {
             Some(x) => (x, line),

--- a/src/key_exchange/group/curve25519.rs
+++ b/src/key_exchange/group/curve25519.rs
@@ -81,7 +81,7 @@ impl KeGroup for Curve25519 {
     }
 
     fn public_key(sk: Self::Sk) -> Self::Pk {
-        (&ED25519_BASEPOINT_TABLE * &sk).to_montgomery()
+        (ED25519_BASEPOINT_TABLE * &sk).to_montgomery()
     }
 
     fn diffie_hellman(pk: Self::Pk, sk: Self::Sk) -> GenericArray<u8, Self::PkLen> {

--- a/src/key_exchange/group/ristretto255.rs
+++ b/src/key_exchange/group/ristretto255.rs
@@ -38,11 +38,8 @@ impl KeGroup for Ristretto255 {
     }
 
     fn deserialize_pk(bytes: &[u8]) -> Result<Self::Pk, InternalError> {
-        if bytes.len() != 32 {
-            return Err(InternalError::PointError);
-        }
-
         CompressedRistretto::from_slice(bytes)
+            .map_err(|_| InternalError::PointError)?
             .decompress()
             .filter(|point| point != &RistrettoPoint::identity())
             .ok_or(InternalError::PointError)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! ### Minimum Supported Rust Version
 //!
-//! Rust **1.57** or higher.
+//! Rust **1.60** or higher.
 //!
 //! # Overview
 //!

--- a/src/tests/parser.rs
+++ b/src/tests/parser.rs
@@ -85,7 +85,7 @@ fn parse_params(input: &str) -> String {
                     let key = iter.next().unwrap().split_whitespace().next().unwrap();
                     let val = iter.next().unwrap().split_whitespace().next().unwrap();
 
-                    param = format!("    \"{}\": \"{}", key, val);
+                    param = format!("    \"{key}\": \"{val}");
                 } else {
                     let s = line.trim().to_string();
                     if s.contains('~') || s.contains('#') {


### PR DESCRIPTION
Depends on https://github.com/facebook/voprf/pull/90 and https://github.com/facebook/voprf/pull/102.
The upgrade to Rust 1.60 also necessitated some Clippy fixes.