### PR TITLE
Only use explicit crate features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,13 @@ rust-version = "1.60"
 version = "2.0.0"
 
 [features]
-curve25519 = ["curve25519-dalek/precomputed-tables"]
+argon2 = ["dep:argon2"]
+curve25519 = ["dep:curve25519-dalek", "curve25519-dalek?/precomputed-tables"]
 default = ["ristretto255-voprf", "serde"]
-ristretto255 = ["curve25519-dalek", "voprf/ristretto255"]
+ristretto255 = ["dep:curve25519-dalek", "voprf/ristretto255"]
 ristretto255-voprf = ["ristretto255", "voprf/ristretto255-ciphersuite"]
-serde = ["serde_", "generic-array/serde", "voprf/serde"]
-std = ["getrandom"]
+serde = ["dep:serde", "generic-array/serde", "voprf/serde"]
+std = ["dep:getrandom"]
 
 [dependencies]
 argon2 = { version = "0.4", default-features = false, features = [
@@ -35,7 +36,7 @@ generic-array = "0.14"
 hkdf = "0.12"
 hmac = "0.12"
 rand = { version = "0.8", default-features = false }
-serde_ = { version = "1", package = "serde", default-features = false, features = [
+serde = { version = "1", default-features = false, features = [
   "derive",
 ], optional = true }
 subtle = { version = "2.3", default-features = false }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -35,11 +35,7 @@ const STR_PRIVATE_KEY: [u8; 10] = *b"PrivateKey";
 const STR_OPAQUE_DERIVE_AUTH_KEY_PAIR: [u8; 24] = *b"OPAQUE-DeriveAuthKeyPair";
 type NonceLen = U32;
 
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, ZeroizeOnDrop)]
 pub(crate) enum InnerEnvelopeMode {
     Zero = 0,
@@ -73,7 +69,7 @@ impl TryFrom<u8> for InnerEnvelopeMode {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "", crate = "serde")
+    serde(bound = "")
 )]
 #[derive_where(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, ZeroizeOnDrop)]
 pub(crate) struct Envelope<CS: CipherSuite>

--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -54,7 +54,7 @@ pub struct TripleDh;
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "", crate = "serde")
+    serde(bound = "")
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; KG::Sk)]
@@ -67,7 +67,7 @@ pub struct Ke1State<KG: KeGroup> {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "", crate = "serde")
+    serde(bound = "")
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; KG::Pk)]
@@ -80,7 +80,7 @@ pub struct Ke1Message<KG: KeGroup> {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "", crate = "serde")
+    serde(bound = "")
 )]
 #[derive_where(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, ZeroizeOnDrop)]
 pub struct Ke2State<D: Hash>
@@ -98,7 +98,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "", crate = "serde")
+    serde(bound = "")
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; KG::Pk)]
@@ -117,7 +117,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "", crate = "serde")
+    serde(bound = "")
 )]
 #[derive_where(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, ZeroizeOnDrop)]
 pub struct Ke3Message<D: Hash>

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -20,13 +20,10 @@ use crate::key_exchange::group::KeGroup;
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(
-        bound(
-            deserialize = "S: serde::Deserialize<'de>",
-            serialize = "S: serde::Serialize"
-        ),
-        crate = "serde"
-    )
+    serde(bound(
+        deserialize = "S: serde::Deserialize<'de>",
+        serialize = "S: serde::Serialize"
+    ))
 )]
 #[derive_where(Clone)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; KG::Pk, S)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1124,9 +1124,6 @@
 #[cfg(any(feature = "std", test))]
 extern crate std;
 
-#[cfg(feature = "serde")]
-extern crate serde_ as serde;
-
 // Error types
 pub mod errors;
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -41,7 +41,7 @@ use crate::opaque::{MaskedResponse, MaskedResponseLen, ServerSetup};
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "", crate = "serde")
+    serde(bound = "")
 )]
 #[derive_where(Clone)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; voprf::BlindedElement<CS::OprfCs>)]
@@ -63,7 +63,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "", crate = "serde")
+    serde(bound = "")
 )]
 #[derive_where(Clone)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; voprf::EvaluationElement<CS::OprfCs>, <CS::KeGroup as KeGroup>::Pk)]
@@ -87,7 +87,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "", crate = "serde")
+    serde(bound = "")
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; <CS::KeGroup as KeGroup>::Pk)]
@@ -113,15 +113,12 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(
-        bound(
-            deserialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, \
-                           CS::KeGroup>>::KE1Message: serde::Deserialize<'de>",
-            serialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE1Message: \
-                         serde::Serialize"
-        ),
-        crate = "serde"
-    )
+    serde(bound(
+        deserialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE1Message: \
+                       serde::Deserialize<'de>",
+        serialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE1Message: \
+                     serde::Serialize"
+    ))
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(
@@ -147,15 +144,12 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(
-        bound(
-            deserialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, \
-                           CS::KeGroup>>::KE2Message: serde::Deserialize<'de>",
-            serialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE2Message: \
-                         serde::Serialize"
-        ),
-        crate = "serde"
-    )
+    serde(bound(
+        deserialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE2Message: \
+                       serde::Deserialize<'de>",
+        serialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE2Message: \
+                     serde::Serialize"
+    ))
 )]
 #[derive_where(Clone)]
 #[derive_where(
@@ -184,15 +178,12 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(
-        bound(
-            deserialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, \
-                           CS::KeGroup>>::KE3Message: serde::Deserialize<'de>",
-            serialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE3Message: \
-                         serde::Serialize"
-        ),
-        crate = "serde"
-    )
+    serde(bound(
+        deserialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE3Message: \
+                       serde::Deserialize<'de>",
+        serialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE3Message: \
+                     serde::Serialize"
+    ))
 )]
 #[derive_where(Clone)]
 #[derive_where(

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -58,13 +58,10 @@ const STR_OPAQUE_DERIVE_KEY_PAIR: &[u8; 20] = b"OPAQUE-DeriveKeyPair";
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(
-        bound(
-            deserialize = "S: serde::Deserialize<'de>",
-            serialize = "S: serde::Serialize"
-        ),
-        crate = "serde"
-    )
+    serde(bound(
+        deserialize = "S: serde::Deserialize<'de>",
+        serialize = "S: serde::Serialize"
+    ))
 )]
 #[derive_where(Clone)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; <CS::KeGroup as KeGroup>::Pk, <CS::KeGroup as KeGroup>::Sk, S)]
@@ -88,7 +85,7 @@ pub struct ServerSetup<
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "", crate = "serde")
+    serde(bound = "")
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(
@@ -113,7 +110,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "", crate = "serde")
+    serde(bound = "")
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; <CS::KeGroup as KeGroup>::Pk)]
@@ -130,18 +127,14 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(
-        bound(
-            deserialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, \
-                           CS::KeGroup>>::KE1Message: serde::Deserialize<'de>, <CS::KeyExchange \
-                           as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE1State: \
-                           serde::Deserialize<'de>",
-            serialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE1Message: \
-                         serde::Serialize, <CS::KeyExchange as KeyExchange<OprfHash<CS>, \
-                         CS::KeGroup>>::KE1State: serde::Serialize"
-        ),
-        crate = "serde"
-    )
+    serde(bound(
+        deserialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE1Message: \
+                       serde::Deserialize<'de>, <CS::KeyExchange as KeyExchange<OprfHash<CS>, \
+                       CS::KeGroup>>::KE1State: serde::Deserialize<'de>",
+        serialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE1Message: \
+                     serde::Serialize, <CS::KeyExchange as KeyExchange<OprfHash<CS>, \
+                     CS::KeGroup>>::KE1State: serde::Serialize"
+    ))
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(
@@ -168,15 +161,12 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(
-        bound(
-            deserialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE2State: \
-                           serde::Deserialize<'de>",
-            serialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE2State: \
-                         serde::Serialize"
-        ),
-        crate = "serde"
-    )
+    serde(bound(
+        deserialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE2State: \
+                       serde::Deserialize<'de>",
+        serialize = "<CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE2State: \
+                     serde::Serialize"
+    ))
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(
@@ -1150,7 +1140,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "", crate = "serde")
+    serde(bound = "")
 )]
 #[derive_where(Clone)]
 #[derive_where(Debug, Eq, Hash, PartialEq)]


### PR DESCRIPTION
Analogous to https://github.com/facebook/voprf/pull/100.
Requires https://github.com/facebook/opaque-ke/pull/304.

> Since we are now using Rust 1.60, we can use explicit crate features.
Rust-Analyzer had some serious issues with that `extern crate serde_ as serde`.
This also removes all implicit features, which is an improvement for users.