### PR TITLE
Update `argon2` to v0.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           - --features serde
         toolchain:
           - stable
-          - 1.62.0
+          - 1.65.0
     name: test
     steps:
       - name: Checkout sources
@@ -78,7 +78,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.62.0
+          - 1.65.0
     name: test simple_login command-line example
     steps:
       - name: install expect
@@ -101,7 +101,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.62.0
+          - 1.65.0
     name: test digital_locker command-line example
     steps:
       - name: install expect

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 OR MIT"
 name = "opaque-ke"
 readme = "README.md"
 repository = "https://github.com/novifinancial/opaque-ke"
-rust-version = "1.62"
+rust-version = "1.65"
 version = "3.0.0-pre.1"
 
 [features]
@@ -21,7 +21,7 @@ serde = ["dep:serde", "generic-array/serde", "voprf/serde"]
 std = ["dep:getrandom"]
 
 [dependencies]
-argon2 = { version = "0.4", default-features = false, features = [
+argon2 = { version = "0.5", default-features = false, features = [
   "alloc",
 ], optional = true }
 curve25519-dalek = { version = "=4.0.0-rc.1", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ opaque-ke = "3.0.0-pre.1"
 
 ### Minimum Supported Rust Version
 
-Rust **1.62** or higher.
+Rust **1.65** or higher.
 
 Audit
 -----

--- a/src/ksf.rs
+++ b/src/ksf.rs
@@ -11,10 +11,6 @@ use generic_array::{ArrayLength, GenericArray};
 
 use crate::errors::InternalError;
 
-/// Recommended salt length for argon2-based password hashing.
-#[cfg(feature = "argon2")]
-const ARGON2_RECOMMENDED_SALT_LEN: usize = 16;
-
 /// Used for the key stretching function in OPAQUE
 pub trait Ksf: Default {
     /// Computes the key stretching function
@@ -44,7 +40,7 @@ impl Ksf for argon2::Argon2<'_> {
         input: GenericArray<u8, L>,
     ) -> Result<GenericArray<u8, L>, InternalError> {
         let mut output = GenericArray::default();
-        self.hash_password_into(&input, &[0; ARGON2_RECOMMENDED_SALT_LEN], &mut output)
+        self.hash_password_into(&input, &[0; argon2::RECOMMENDED_SALT_LEN], &mut output)
             .map_err(|_| InternalError::KsfError)?;
         Ok(output)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! ### Minimum Supported Rust Version
 //!
-//! Rust **1.62** or higher.
+//! Rust **1.65** or higher.
 //!
 //! # Overview
 //!


### PR DESCRIPTION
Updates `argon2` to v0.5.
Doesn't really include any interesting changes for us except we now don't have to specify our own default salt length, because it's provided by `argon2` now.

See the [CHANGELOG](https://github.com/RustCrypto/password-hashes/blob/argon2-v0.5.0/argon2/CHANGELOG.md#050-2023-03-04).