### PR TITLE
Fix zeroize dependency in a more future-proof fashion

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           - u32_backend
         toolchain:
           - nightly
-          - 1.51.0
+          - 1.56.0
     name: test
     steps:
       - name: Checkout sources
@@ -94,7 +94,7 @@ jobs:
       matrix:
         toolchain:
           - nightly
-          - 1.51.0
+          - 1.56.0
     name: test simple_login command-line example
     steps:
       - name: install expect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.0 (May 13, 2023)
+
+* Update zeroize dependency to allow for beyond version 1.5
+* Increase MSRV to 1.56
+
 ## 0.6.1 (January 25, 2022)
 
 * Fix `zeroize` implementing `Drop` on `enum`s now

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rand = "0.8"
 serde = { version = "1", features = ["derive"], optional = true }
 subtle = { version = "2.3.0", default-features = false }
 thiserror = "1.0.22"
-zeroize = { version = "~1.5", features = ["zeroize_derive"] }
+zeroize = { version = "1.5", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 anyhow = "1.0.35"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opaque-ke"
-version = "0.6.1"
+version = "0.7.0"
 repository = "https://github.com/novifinancial/opaque-ke"
 keywords = ["cryptography", "crypto", "opaque", "passwords", "authentication"]
 description = "An implementation of the OPAQUE password-authenticated key exchange protocol"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-opaque-ke = "0.6.1"
+opaque-ke = "0.7.0"
 ```
 
 Resources


### PR DESCRIPTION
Also, bump to 0.6.2 for release.

I'm trying to publish a crate that depends on opaque 0.6 and (indirectly) on zeroize 1.5.7. The 0.6.1 of opaque_ke is still on zeroize ~1.1, so it's not compatible.

For me to release my crate, I'd need a 0.6.2 release.

(note that I _know_ that 0.6 is deprecated, but my crate will depend on _both_ opaque 0.6 and 3.0+ and will allow users to do a smooth transitions without having to reset their passwords)