### PR TITLE
Bump `voprf` to v0.5.0-pre.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ std = ["dep:getrandom"]
 argon2 = { version = "0.5", default-features = false, features = [
   "alloc",
 ], optional = true }
-curve25519-dalek = { version = "=4.0.0-rc.1", default-features = false, features = [
+curve25519-dalek = { version = "=4.0.0-rc.2", default-features = false, features = [
   "rand_core",
   "zeroize",
 ], optional = true }
@@ -40,7 +40,7 @@ serde = { version = "1", default-features = false, features = [
   "derive",
 ], optional = true }
 subtle = { version = "2.3", default-features = false }
-voprf = { version = "=0.5.0-pre.3", default-features = false, features = [
+voprf = { version = "=0.5.0-pre.4", default-features = false, features = [
   "danger",
 ] }
 zeroize = { version = "1.5", features = ["zeroize_derive"] }


### PR DESCRIPTION
Bumps `voprf` to v0.5.0-pre.4 and `curve25519-dalek` to v4.0.0-rc.2.

Replaces #320.