### PR TITLE
Bump `curve25519-dalek` to v4.0.0-rc.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ std = ["dep:getrandom"]
 argon2 = { version = "0.5", default-features = false, features = [
   "alloc",
 ], optional = true }
-curve25519-dalek = { version = "=4.0.0-rc.2", default-features = false, features = [
+curve25519-dalek = { version = "=4.0.0-rc.3", default-features = false, features = [
   "zeroize",
 ], optional = true }
 derive-where = { version = "1", features = ["zeroize-on-drop"] }
@@ -39,7 +39,7 @@ serde = { version = "1", default-features = false, features = [
   "derive",
 ], optional = true }
 subtle = { version = "2.3", default-features = false }
-voprf = { version = "=0.5.0-pre.4", default-features = false, features = [
+voprf = { version = "=0.5.0-pre.5", default-features = false, features = [
   "danger",
 ] }
 zeroize = { version = "1.5", features = ["zeroize_derive"] }


### PR DESCRIPTION
The `Scalar` type isn't compatible with X25519 anymore, so instead we use a plain `[u8; 32]`.

Requires https://github.com/facebook/voprf/pull/113.