### PR TITLE
Updating voprf dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           - --features serde
         toolchain:
           - stable
-          - 1.70.0
+          - 1.74.0
     name: test
     steps:
       - name: Checkout sources
@@ -78,7 +78,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.70.0
+          - 1.74.0
     name: test simple_login command-line example
     steps:
       - name: install expect
@@ -101,7 +101,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.70.0
+          - 1.74.0
     name: test digital_locker command-line example
     steps:
       - name: install expect

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,7 @@ serde = { version = "1", default-features = false, features = [
   "derive",
 ], optional = true }
 subtle = { version = "2.3", default-features = false }
-voprf = { version = "=0.5.0-pre.6", default-features = false, features = [
-  "danger",
-] }
+voprf = { version = "0.5", default-features = false, features = ["danger"] }
 zeroize = { version = "1.5", features = ["zeroize_derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -69,7 +67,7 @@ proptest = "1"
 rand = "0.8"
 regex = "1"
 # MSRV
-rustyline = "13"
+rustyline = "14"
 scrypt = "0.11"
 serde_json = "1"
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ opaque-ke = "3.0.0-pre.4"
 
 ### Minimum Supported Rust Version
 
-Rust **1.70** or higher.
+Rust **1.74** or higher.
 
 Audit
 -----

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,7 @@ pub enum InternalError<T = Infallible> {
     Custom(T),
     /// Deserializing from a byte sequence failed
     InvalidByteSequence,
+    #[allow(clippy::doc_markdown)]
     /// Invalid length for {name}: expected {len}, but is actually {actual_len}.
     SizeError {
         /// name

--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -226,7 +226,7 @@ where
             .chain_iter(id_s.into_iter())
             .chain_iter(l2_bytes)
             .chain(server_nonce)
-            .chain(&server_e_kp.public().serialize());
+            .chain(server_e_kp.public().serialize());
 
         let result = derive_3dh_keys::<D, KG, S>(
             TripleDhComponents {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! ### Minimum Supported Rust Version
 //!
-//! Rust **1.65** or higher.
+//! Rust **1.74** or higher.
 //!
 //! # Overview
 //!

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -716,13 +716,7 @@ where
         };
 
         let client_s_pk = record.0.client_s_pk.clone();
-
-        let context = if let Some(context) = context {
-            context
-        } else {
-            &[]
-        };
-
+        let context = context.unwrap_or(&[]);
         let server_s_sk = server_setup.keypair.private();
         let server_s_pk = server_s_sk.public_key()?;
 

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -13,7 +13,7 @@ use generic_array::typenum::{U0, U2};
 use generic_array::{ArrayLength, GenericArray};
 use hmac::Mac;
 
-use crate::errors::{InternalError, ProtocolError};
+use crate::errors::ProtocolError;
 
 // Corresponds to the I2OSP() function from RFC8017
 pub(crate) fn i2osp<L: ArrayLength<u8>>(
@@ -150,20 +150,6 @@ impl<T: Mac> MacExt for T {
     fn update_iter<'a>(&mut self, iter: impl Iterator<Item = &'a [u8]>) {
         for bytes in iter {
             self.update(bytes);
-        }
-    }
-}
-
-pub(crate) trait GenericArrayExt {
-    fn try_from_slice(slice: &[u8]) -> Result<&Self, InternalError>;
-}
-
-impl<L: ArrayLength<u8>> GenericArrayExt for GenericArray<u8, L> {
-    fn try_from_slice(slice: &[u8]) -> Result<&Self, InternalError> {
-        if slice.len() == L::USIZE {
-            Ok(Self::from_slice(slice))
-        } else {
-            Err(InternalError::InvalidByteSequence)
         }
     }
 }

--- a/src/tests/full_test.rs
+++ b/src/tests/full_test.rs
@@ -1319,7 +1319,7 @@ fn test_credential_finalization() -> Result<(), ProtocolError> {
 
         assert_eq!(
             hex::encode(&parameters.server_s_pk),
-            hex::encode(&client_login_finish_result.server_s_pk.serialize())
+            hex::encode(client_login_finish_result.server_s_pk.serialize())
         );
         assert_eq!(
             hex::encode(&parameters.session_key),

--- a/src/tests/test_opaque_vectors.rs
+++ b/src/tests/test_opaque_vectors.rs
@@ -41,6 +41,7 @@ pub struct OpaqueTestVectorParameters {
     pub dummy_private_key: Vec<u8>,
     pub dummy_masking_key: Vec<u8>,
     pub context: Vec<u8>,
+    #[allow(dead_code)] // client_private_key is not tested in the test vectors
     pub client_private_key: Option<Vec<u8>>,
     pub client_keyshare_seed: Vec<u8>,
     pub server_public_key: Vec<u8>,
@@ -56,8 +57,6 @@ pub struct OpaqueTestVectorParameters {
     pub envelope_nonce: Vec<u8>,
     pub client_nonce: Vec<u8>,
     pub server_nonce: Vec<u8>,
-    pub client_info: Vec<u8>,
-    pub server_info: Vec<u8>,
     pub registration_request: Vec<u8>,
     pub registration_response: Vec<u8>,
     pub registration_upload: Vec<u8>,
@@ -139,8 +138,6 @@ where
         envelope_nonce: parse!(values, "envelope_nonce"),
         client_nonce: parse!(values, "client_nonce"),
         server_nonce: parse!(values, "server_nonce"),
-        client_info: parse!(values, "client_info"),
-        server_info: parse!(values, "server_info"),
         registration_request: parse!(values, "registration_request"),
         registration_response: parse!(values, "registration_response"),
         registration_upload: parse!(values, "registration_upload"),
@@ -371,6 +368,10 @@ where
             RegistrationRequest::deserialize(&parameters.registration_request).unwrap(),
             &parameters.credential_identifier,
         )?;
+        assert_eq!(
+            hex::encode(&parameters.server_public_key),
+            hex::encode(server_setup.keypair().public().serialize()),
+        );
         assert_eq!(
             hex::encode(&parameters.oprf_key),
             hex::encode(server_registration_start_result.oprf_key)


### PR DESCRIPTION
This primarily fixes recent clippy issues and also updates the voprf dependency. Also bumps MSRV to 1.74.

Addresses #359 