### PR TITLE
Rework `SecretKey` API to facilitate async

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,10 @@ jobs:
           - stable
           - 1.83.0
     name: test
+    env:
+      PKCS11_MODULE: /usr/lib/softhsm/libsofthsm2.so
+      SOFTHSM2_CONF: /tmp/softhsm2.conf
+      RUSTFLAGS: --cfg test_hsm
     steps:
       - name: Checkout sources
         uses: actions/checkout@main
@@ -35,6 +39,13 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           override: true
+
+      - name: Install SoftHSM
+        run: |
+          sudo apt-get update -y -qq &&
+          sudo apt-get install -y -qq libsofthsm2 &&
+          mkdir /tmp/tokens
+          echo "directories.tokendir = /tmp/tokens" > /tmp/softhsm2.conf
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ curve25519 = ["dep:curve25519-dalek"]
 default = ["ristretto255-voprf", "serde"]
 ristretto255 = ["dep:curve25519-dalek", "voprf/ristretto255"]
 ristretto255-voprf = ["ristretto255", "voprf/ristretto255-ciphersuite"]
-serde = ["dep:serde", "generic-array/serde", "voprf/serde"]
+serde = ["dep:serde", "generic-array/serde", "voprf/serde", "zeroize/serde"]
 std = ["dep:getrandom"]
 
 [dependencies]
@@ -27,7 +27,7 @@ argon2 = { version = "0.5", default-features = false, features = [
 curve25519-dalek = { version = "4", default-features = false, features = [
   "zeroize",
 ], optional = true }
-derive-where = { version = "1", features = ["zeroize-on-drop"] }
+derive-where = { version = "1.3", features = ["zeroize-on-drop"] }
 digest = "0.10"
 displaydoc = { version = "0.2", default-features = false }
 elliptic-curve = { version = "0.13", features = ["hash2curve", "sec1"] }
@@ -46,25 +46,32 @@ zeroize = { version = "1.8", features = ["zeroize_derive"] }
 getrandom = { version = "0.2", features = ["js"], optional = true }
 
 [dev-dependencies]
+anyhow = "1"
 bincode = "1"
 chacha20poly1305 = "0.10"
 criterion = "0.5"
+cryptoki = "0.9"
+elliptic-curve = { version = "0.13", features = ["alloc", "pkcs8"] }
 hex = "0.4"
 p256 = { version = "0.13", default-features = false, features = [
   "hash2curve",
+  "pkcs8",
   "voprf",
 ] }
 p384 = { version = "0.13", default-features = false, features = [
   "hash2curve",
+  "pkcs8",
   "voprf",
 ] }
 p521 = { version = "0.13.3", default-features = false, features = [
   "hash2curve",
+  "pkcs8",
   "voprf",
 ] }
 proptest = "1"
 rand = "0.8"
 regex = "1"
+thiserror = "2"
 # MSRV
 rustyline = "15"
 scrypt = "0.11"
@@ -82,3 +89,6 @@ targets = []
 [[example]]
 name = "simple_login"
 required-features = ["argon2"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test_hsm)'] }

--- a/deny.toml
+++ b/deny.toml
@@ -42,7 +42,8 @@ yanked = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-  #"RUSTSEC-0000-0000",
+  # dev-dependency
+  "RUSTSEC-2024-0436",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/src/ciphersuite.rs
+++ b/src/ciphersuite.rs
@@ -36,7 +36,7 @@ where
     /// A VOPRF ciphersuite, see [`voprf::CipherSuite`].
     type OprfCs: voprf::CipherSuite;
     /// A `Group` used for the `KeyExchange`.
-    type KeGroup: KeGroup;
+    type KeGroup: 'static + KeGroup;
     /// A key exchange protocol
     type KeyExchange: KeyExchange<OprfHash<Self>, Self::KeGroup>;
     /// A key stretching function, typically used for password hashing

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -24,7 +24,7 @@ use crate::errors::utils::check_slice_size;
 use crate::errors::{InternalError, ProtocolError};
 use crate::hash::OutputSize;
 use crate::key_exchange::group::KeGroup;
-use crate::keypair::{KeyPair, PublicKey};
+use crate::keypair::{KeyPair, PrivateKey, PrivateKeySerialization, PublicKey};
 use crate::opaque::{bytestrings_from_identifiers, Identifiers};
 use crate::serialization::{Input, MacExt};
 
@@ -303,7 +303,7 @@ fn build_inner_envelope_internal<CS: CipherSuite>(
         .expand(&nonce.concat(STR_PRIVATE_KEY.into()), &mut keypair_seed)
         .map_err(|_| InternalError::HkdfError)?;
     let client_static_keypair =
-        KeyPair::<CS::KeGroup>::from_private_key_slice(&CS::KeGroup::serialize_sk(
+        PrivateKey::<CS::KeGroup>::deserialize_key_pair(&CS::KeGroup::serialize_sk(
             CS::KeGroup::derive_auth_keypair::<CS::OprfCs>(keypair_seed)?,
         ))?;
 
@@ -319,7 +319,7 @@ fn recover_keys_internal<CS: CipherSuite>(
         .expand(&nonce.concat(STR_PRIVATE_KEY.into()), &mut keypair_seed)
         .map_err(|_| InternalError::HkdfError)?;
     let client_static_keypair =
-        KeyPair::<CS::KeGroup>::from_private_key_slice(&CS::KeGroup::serialize_sk(
+        PrivateKey::<CS::KeGroup>::deserialize_key_pair(&CS::KeGroup::serialize_sk(
             CS::KeGroup::derive_auth_keypair::<CS::OprfCs>(keypair_seed)?,
         ))?;
 

--- a/src/key_exchange/group/mod.rs
+++ b/src/key_exchange/group/mod.rs
@@ -22,7 +22,7 @@ use generic_array::{ArrayLength, GenericArray};
 use rand::{CryptoRng, RngCore};
 use zeroize::Zeroize;
 
-use crate::errors::InternalError;
+use crate::errors::{InternalError, ProtocolError};
 
 const STR_OPAQUE_DERIVE_AUTH_KEY_PAIR: [u8; 33] = *b"OPAQUE-DeriveDiffieHellmanKeyPair";
 
@@ -41,7 +41,7 @@ pub trait KeGroup {
     fn serialize_pk(pk: Self::Pk) -> GenericArray<u8, Self::PkLen>;
 
     /// Return a public key from its fixed-length bytes representation
-    fn deserialize_pk(bytes: &[u8]) -> Result<Self::Pk, InternalError>;
+    fn deserialize_pk(bytes: &[u8]) -> Result<Self::Pk, ProtocolError>;
 
     /// Generate a random secret key
     fn random_sk<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Sk;
@@ -104,14 +104,11 @@ pub trait KeGroup {
     /// Return a public key from its secret key
     fn public_key(sk: Self::Sk) -> Self::Pk;
 
-    /// Diffie-Hellman key exchange
-    fn diffie_hellman(pk: Self::Pk, sk: Self::Sk) -> GenericArray<u8, Self::PkLen>;
-
     /// Serializes `self`
     fn serialize_sk(sk: Self::Sk) -> GenericArray<u8, Self::SkLen>;
 
     /// Return a public key from its fixed-length bytes representation
-    fn deserialize_sk(bytes: &[u8]) -> Result<Self::Sk, InternalError>;
+    fn deserialize_sk(bytes: &[u8]) -> Result<Self::Sk, ProtocolError>;
 }
 
 // Helper functions used to compute DeriveAuthKeyPair() (taken from the voprf

--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -109,14 +109,12 @@ where
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(bound(
-        deserialize = "D: serde::Deserialize<'de>, KeyPair<KG>: serde::Deserialize<'de>, \
-                       PublicKey<KG>: serde::Deserialize<'de>",
-        serialize = "D: serde::Serialize, KeyPair<KG>: serde::Serialize, PublicKey<KG>: \
-                     serde::Serialize",
+        deserialize = "D: serde::Deserialize<'de>,  PublicKey<KG>: serde::Deserialize<'de>",
+        serialize = "D: serde::Serialize,  PublicKey<KG>: serde::Serialize",
     ))
 )]
 #[derive_where(Clone)]
-#[derive_where(Debug, Eq, Hash, PartialEq; D, KeyPair<KG>, PublicKey<KG>)]
+#[derive_where(Debug, Eq, Hash, PartialEq; D, PublicKey<KG>)]
 pub struct Ke2Builder<D: Hash, KG: KeGroup>
 where
     D::Core: ProxyHash,
@@ -412,7 +410,6 @@ fn derive_3dh_keys<D: Hash, KG: KeGroup>(
     hashed_derivation_transcript: &[u8],
 ) -> Result<TripleDhDerivationResult<D>, ProtocolError>
 where
-    KG::Sk: DiffieHellman<KG>,
     D::Core: ProxyHash,
     <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
     Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,

--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -19,6 +19,7 @@ use generic_array::{ArrayLength, GenericArray};
 use hkdf::{Hkdf, HkdfExtract};
 use hmac::{Hmac, Mac};
 use rand::{CryptoRng, RngCore};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::errors::utils::{check_slice_size, check_slice_size_atleast};
 use crate::errors::{InternalError, ProtocolError};
@@ -27,7 +28,7 @@ use crate::key_exchange::group::KeGroup;
 use crate::key_exchange::traits::{
     Deserialize, GenerateKe2Result, GenerateKe3Result, KeyExchange, Serialize,
 };
-use crate::keypair::{KeyPair, PrivateKey, PublicKey, SecretKey};
+use crate::keypair::{KeyPair, PrivateKey, PublicKey};
 use crate::serialization::{Input, UpdateExt};
 
 ///////////////
@@ -49,6 +50,14 @@ static STR_OPAQUE: &[u8] = b"OPAQUE-";
 ////////////////////////////
 
 /// The Triple Diffie-Hellman key exchange implementation
+///
+/// # Remote Key
+///
+/// [`ServerLoginBuilder::data()`](crate::ServerLoginBuilder::data()) will
+/// return the client's ephemeral public key.
+/// [`ServerLoginBuilder::build()`](crate::ServerLoginBuilder::build()) expects
+/// a shared secret computed through Diffie-Hellman from the server's private
+/// key and the given public key.
 pub struct TripleDh;
 
 /// The client state produced after the first key exchange message
@@ -95,6 +104,33 @@ where
     session_key: Output<D>,
 }
 
+/// Builder for the second key exchange message
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(bound(
+        deserialize = "D: serde::Deserialize<'de>, KeyPair<KG>: serde::Deserialize<'de>, \
+                       PublicKey<KG>: serde::Deserialize<'de>",
+        serialize = "D: serde::Serialize, KeyPair<KG>: serde::Serialize, PublicKey<KG>: \
+                     serde::Serialize",
+    ))
+)]
+#[derive_where(Clone)]
+#[derive_where(Debug, Eq, Hash, PartialEq; D, KeyPair<KG>, PublicKey<KG>)]
+pub struct Ke2Builder<D: Hash, KG: KeGroup>
+where
+    D::Core: ProxyHash,
+    <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
+    Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+{
+    server_nonce: GenericArray<u8, NonceLen>,
+    transcript_hasher: D,
+    client_e_pk: PublicKey<KG>,
+    server_e_pk: PublicKey<KG>,
+    shared_secret_1: GenericArray<u8, KG::PkLen>,
+    shared_secret_3: GenericArray<u8, KG::PkLen>,
+}
+
 /// The second key exchange message
 #[cfg_attr(
     feature = "serde",
@@ -130,13 +166,20 @@ where
     mac: Output<D>,
 }
 
+/// Trait required by [`KeGroup::Sk`] to be compatible with [`TripleDh`].
+pub trait DiffieHellman<KG: KeGroup> {
+    /// Diffie-Hellman key exchange.
+    fn diffie_hellman(self, pk: KG::Pk) -> GenericArray<u8, KG::PkLen>;
+}
+
 ////////////////////////////////
 // High-level Implementations //
 // ========================== //
 ////////////////////////////////
 
-impl<D: Hash, KG: KeGroup> KeyExchange<D, KG> for TripleDh
+impl<D: Hash, KG: KeGroup + 'static> KeyExchange<D, KG> for TripleDh
 where
+    KG::Sk: DiffieHellman<KG>,
     D::Core: ProxyHash,
     <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
     Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
@@ -158,6 +201,9 @@ where
     type KE1State = Ke1State<KG>;
     type KE2State = Ke2State<D>;
     type KE1Message = Ke1Message<KG>;
+    type KE2Builder = Ke2Builder<D, KG>;
+    type KE2BuilderData<'a> = &'a PublicKey<KG>;
+    type KE2BuilderInput = GenericArray<u8, KG::PkLen>;
     type KE2Message = Ke2Message<D, KG>;
     type KE3Message = Ke3Message<D>;
 
@@ -181,71 +227,82 @@ where
         ))
     }
 
-    #[allow(clippy::type_complexity)]
-    fn generate_ke2<
-        'a,
-        'b,
-        'c,
-        'd,
-        OprfCs: voprf::CipherSuite,
-        R: RngCore + CryptoRng,
-        S: SecretKey<KG>,
-    >(
+    fn ke2_builder<'a, 'b, 'c, 'd, OprfCs: voprf::CipherSuite, R: RngCore + CryptoRng>(
         rng: &mut R,
         serialized_credential_request: impl Iterator<Item = &'a [u8]>,
-        l2_bytes: impl Iterator<Item = &'b [u8]>,
+        serialized_credential_response: impl Iterator<Item = &'b [u8]>,
         ke1_message: Self::KE1Message,
         client_s_pk: PublicKey<KG>,
-        server_s_sk: S,
         id_u: impl Iterator<Item = &'c [u8]>,
         id_s: impl Iterator<Item = &'d [u8]>,
         context: &[u8],
-    ) -> Result<GenerateKe2Result<Self, D, KG>, ProtocolError<S::Error>> {
-        let server_e_kp = KeyPair::<KG>::generate_random::<OprfCs, _>(rng);
+    ) -> Result<Self::KE2Builder, ProtocolError> {
+        let server_e = KeyPair::<KG>::generate_random::<OprfCs, _>(rng);
         let server_nonce = generate_nonce::<R>(rng);
 
-        let mut transcript_hasher = D::new()
+        let transcript_hasher = D::new()
             .chain(STR_CONTEXT)
-            .chain_iter(
-                Input::<U2>::from(context)
-                    .map_err(ProtocolError::into_custom)?
-                    .iter(),
-            )
+            .chain_iter(Input::<U2>::from(context)?.iter())
             .chain_iter(id_u.into_iter())
             .chain_iter(serialized_credential_request)
             .chain_iter(id_s.into_iter())
-            .chain_iter(l2_bytes)
+            .chain_iter(serialized_credential_response)
             .chain(server_nonce)
-            .chain(server_e_kp.public().serialize());
+            .chain(server_e.public().serialize());
 
-        let result = derive_3dh_keys::<D, KG, S>(
-            TripleDhComponents {
-                pk1: ke1_message.client_e_pk.clone(),
-                sk1: server_e_kp.private().clone(),
-                pk2: ke1_message.client_e_pk.clone(),
-                sk2: server_s_sk,
-                pk3: client_s_pk,
-                sk3: server_e_kp.private().clone(),
-            },
-            &transcript_hasher.clone().finalize(),
+        let shared_secret_1 = server_e
+            .private()
+            .ke_diffie_hellman(&ke1_message.client_e_pk);
+        let shared_secret_3 = server_e.private().ke_diffie_hellman(&client_s_pk);
+
+        Ok(Ke2Builder {
+            server_nonce,
+            transcript_hasher,
+            client_e_pk: ke1_message.client_e_pk.clone(),
+            server_e_pk: server_e.public().clone(),
+            shared_secret_1,
+            shared_secret_3,
+        })
+    }
+
+    fn ke2_builder_data(builder: &Self::KE2Builder) -> Self::KE2BuilderData<'_> {
+        &builder.client_e_pk
+    }
+
+    fn generate_ke2_input(
+        builder: &Self::KE2Builder,
+        server_s_sk: &PrivateKey<KG>,
+    ) -> Self::KE2BuilderInput {
+        server_s_sk.ke_diffie_hellman(&builder.client_e_pk)
+    }
+
+    fn build_ke2(
+        mut builder: Self::KE2Builder,
+        shared_secret_2: Self::KE2BuilderInput,
+    ) -> Result<GenerateKe2Result<Self, D, KG>, ProtocolError> {
+        let result = derive_3dh_keys::<D, KG>(
+            builder.shared_secret_1.clone(),
+            shared_secret_2,
+            builder.shared_secret_3.clone(),
+            &builder.transcript_hasher.clone().finalize(),
         )?;
 
         let mut mac_hasher =
             Hmac::<D>::new_from_slice(&result.1).map_err(|_| InternalError::HmacError)?;
-        mac_hasher.update(&transcript_hasher.clone().finalize());
+        mac_hasher.update(&builder.transcript_hasher.clone().finalize());
         let mac = mac_hasher.finalize().into_bytes();
 
-        Digest::update(&mut transcript_hasher, &mac);
+        Digest::update(&mut builder.transcript_hasher, &mac);
 
         Ok((
             Ke2State {
                 km3: result.2,
-                hashed_transcript: transcript_hasher.finalize(),
+                hashed_transcript: builder.transcript_hasher.clone().finalize(),
                 session_key: result.0,
             },
             Ke2Message {
-                server_nonce,
-                server_e_pk: server_e_kp.public().clone(),
+                server_nonce: builder.server_nonce,
+                server_e_pk: builder.server_e_pk.clone(),
                 mac,
             },
             #[cfg(test)]
@@ -276,15 +333,12 @@ where
             .chain_iter(l2_component)
             .chain(ke2_message.to_bytes_without_mac());
 
-        let result = derive_3dh_keys::<D, KG, PrivateKey<KG>>(
-            TripleDhComponents {
-                pk1: ke2_message.server_e_pk.clone(),
-                sk1: ke1_state.client_e_sk.clone(),
-                pk2: server_s_pk,
-                sk2: ke1_state.client_e_sk.clone(),
-                pk3: ke2_message.server_e_pk.clone(),
-                sk3: client_s_sk,
-            },
+        let result = derive_3dh_keys::<D, KG>(
+            ke1_state
+                .client_e_sk
+                .ke_diffie_hellman(&ke2_message.server_e_pk),
+            ke1_state.client_e_sk.ke_diffie_hellman(&server_s_pk),
+            client_s_sk.ke_diffie_hellman(&ke2_message.server_e_pk),
             &transcript_hasher.clone().finalize(),
         )?;
 
@@ -335,16 +389,6 @@ where
 //==================== //
 /////////////////////////
 
-// The triple of public and private components used in the 3DH computation
-struct TripleDhComponents<KG: KeGroup, S: SecretKey<KG>> {
-    pk1: PublicKey<KG>,
-    sk1: PrivateKey<KG>,
-    pk2: PublicKey<KG>,
-    sk2: S,
-    pk3: PublicKey<KG>,
-    sk3: PrivateKey<KG>,
-}
-
 // Consists of a session key, followed by two mac keys: (session_key, km2, km3)
 #[cfg(not(test))]
 type TripleDhDerivationResult<D> = (Output<D>, Output<D>, Output<D>);
@@ -361,47 +405,38 @@ type TripleDhDerivationResult<D> = (Output<D>, Output<D>, Output<D>, Output<D>);
 // Internal function which takes the public and private components of the client
 // and server keypairs, along with some auxiliary metadata, to produce the
 // session key and two MAC keys
-fn derive_3dh_keys<D: Hash, KG: KeGroup, S: SecretKey<KG>>(
-    dh: TripleDhComponents<KG, S>,
+fn derive_3dh_keys<D: Hash, KG: KeGroup>(
+    shared_secret_1: GenericArray<u8, KG::PkLen>,
+    shared_secret_2: GenericArray<u8, KG::PkLen>,
+    shared_secret_3: GenericArray<u8, KG::PkLen>,
     hashed_derivation_transcript: &[u8],
-) -> Result<TripleDhDerivationResult<D>, ProtocolError<S::Error>>
+) -> Result<TripleDhDerivationResult<D>, ProtocolError>
 where
+    KG::Sk: DiffieHellman<KG>,
     D::Core: ProxyHash,
     <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
     Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
 {
     let mut hkdf = HkdfExtract::<D>::new(None);
 
-    hkdf.input_ikm(
-        &dh.sk1
-            .diffie_hellman(dh.pk1)
-            .map_err(InternalError::into_custom)?,
-    );
-    hkdf.input_ikm(&dh.sk2.diffie_hellman(dh.pk2)?);
-    hkdf.input_ikm(
-        &dh.sk3
-            .diffie_hellman(dh.pk3)
-            .map_err(InternalError::into_custom)?,
-    );
+    hkdf.input_ikm(&shared_secret_1);
+    hkdf.input_ikm(&shared_secret_2);
+    hkdf.input_ikm(&shared_secret_3);
 
     let (_, extracted_ikm) = hkdf.finalize();
     let handshake_secret = derive_secrets::<D>(
         &extracted_ikm,
         STR_HANDSHAKE_SECRET,
         hashed_derivation_transcript,
-    )
-    .map_err(ProtocolError::into_custom)?;
+    )?;
     let session_key = derive_secrets::<D>(
         &extracted_ikm,
         STR_SESSION_KEY,
         hashed_derivation_transcript,
-    )
-    .map_err(ProtocolError::into_custom)?;
+    )?;
 
-    let km2 = hkdf_expand_label::<D>(&handshake_secret, STR_SERVER_MAC, b"")
-        .map_err(ProtocolError::into_custom)?;
-    let km3 = hkdf_expand_label::<D>(&handshake_secret, STR_CLIENT_MAC, b"")
-        .map_err(ProtocolError::into_custom)?;
+    let km2 = hkdf_expand_label::<D>(&handshake_secret, STR_SERVER_MAC, b"")?;
+    let km3 = hkdf_expand_label::<D>(&handshake_secret, STR_CLIENT_MAC, b"")?;
 
     Ok((
         session_key,
@@ -577,6 +612,32 @@ where
             .concat(self.hashed_transcript.clone())
             .concat(self.session_key.clone())
     }
+}
+
+impl<KG: KeGroup, D: Hash> Drop for Ke2Builder<D, KG>
+where
+    D::Core: ProxyHash,
+    <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
+    Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+{
+    fn drop(&mut self) {
+        struct AssertZeroizeOnDrop<'a, T: ZeroizeOnDrop>(#[allow(unused)] &'a T);
+
+        self.server_nonce.zeroize();
+        self.transcript_hasher.reset();
+        let _ = AssertZeroizeOnDrop(&self.client_e_pk);
+        let _ = AssertZeroizeOnDrop(&self.server_e_pk);
+        self.shared_secret_1.zeroize();
+        self.shared_secret_3.zeroize();
+    }
+}
+
+impl<KG: KeGroup, D: Hash> ZeroizeOnDrop for Ke2Builder<D, KG>
+where
+    D::Core: ProxyHash,
+    <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
+    Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+{
 }
 
 impl<KG: KeGroup, D: Hash> Deserialize for Ke2Message<D, KG>

--- a/src/serialization/tests.rs
+++ b/src/serialization/tests.rs
@@ -28,7 +28,7 @@ use crate::key_exchange::traits::{
     Deserialize, Ke1MessageLen, Ke1StateLen, Ke2MessageLen, KeyExchange, Serialize,
 };
 use crate::key_exchange::tripledh::{NonceLen, TripleDh};
-use crate::keypair::{KeyPair, SecretKey};
+use crate::keypair::KeyPair;
 use crate::messages::CredentialResponseWithoutKeLen;
 use crate::opaque::{ClientLoginLen, ClientRegistrationLen, MaskedResponseLen};
 use crate::serialization::{i2osp, os2ip};

--- a/src/tests/full_test.rs
+++ b/src/tests/full_test.rs
@@ -27,8 +27,7 @@ use crate::errors::*;
 use crate::hash::OutputSize;
 use crate::key_exchange::group::KeGroup;
 use crate::key_exchange::traits::{Ke1MessageLen, Ke1StateLen, Ke2MessageLen};
-use crate::key_exchange::tripledh::{NonceLen, TripleDh};
-use crate::keypair::SecretKey;
+use crate::key_exchange::tripledh::{DiffieHellman, NonceLen, TripleDh};
 use crate::ksf::Identity;
 use crate::messages::{
     CredentialRequestLen, CredentialResponseLen, CredentialResponseWithoutKeLen,
@@ -1497,6 +1496,7 @@ fn test_zeroize_client_login_start() -> Result<(), ProtocolError> {
         _test_vector: &str,
     ) -> Result<(), ProtocolError>
     where
+        <CS::KeGroup as KeGroup>::Sk: DiffieHellman<CS::KeGroup>,
         // CredentialRequest: KgPk + Ke1Message
         <OprfGroup<CS> as Group>::ElemLen: Add<Sum<NonceLen, <CS::KeGroup as KeGroup>::PkLen>>,
         CredentialRequestLen<CS>: ArrayLength<u8>,
@@ -1595,6 +1595,7 @@ fn test_zeroize_client_login_finish() -> Result<(), ProtocolError> {
         _test_vector: &str,
     ) -> Result<(), ProtocolError>
     where
+        <CS::KeGroup as KeGroup>::Sk: DiffieHellman<CS::KeGroup>,
         // MaskedResponse: (Nonce + Hash) + KePk
         NonceLen: Add<OutputSize<OprfHash<CS>>>,
         Sum<NonceLen, OutputSize<OprfHash<CS>>>:

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,4 +12,6 @@ mod full_test_vectors;
 pub mod mock_rng;
 mod opaque_vectors;
 mod parser;
+#[cfg(test_hsm)]
+mod remote_key;
 mod test_opaque_vectors;

--- a/src/tests/remote_key.rs
+++ b/src/tests/remote_key.rs
@@ -1,0 +1,373 @@
+use std::env;
+use std::ops::Add;
+use std::sync::{LazyLock, Mutex};
+use std::vec::Vec;
+
+use cryptoki::context::{CInitializeArgs, Pkcs11};
+use cryptoki::mechanism::elliptic_curve::{EcKdf, Ecdh1DeriveParams};
+use cryptoki::mechanism::Mechanism;
+use cryptoki::object::{Attribute, AttributeType, KeyType, ObjectClass, ObjectHandle};
+use cryptoki::session::{Session, UserType};
+use cryptoki::types::AuthPin;
+use elliptic_curve::group::Curve;
+use elliptic_curve::pkcs8::der::asn1::{OctetString, OctetStringRef};
+use elliptic_curve::pkcs8::der::{Decode, Encode};
+use elliptic_curve::pkcs8::{AssociatedOid, ObjectIdentifier};
+use elliptic_curve::point::{AffineCoordinates, DecompressPoint};
+use elliptic_curve::sec1::{ModulusSize, Tag, ToEncodedPoint};
+use elliptic_curve::{AffinePoint, CurveArithmetic, FieldBytesSize, Group, ProjectivePoint};
+use generic_array::typenum::Sum;
+use generic_array::{ArrayLength, GenericArray};
+use p256::NistP256;
+use p384::NistP384;
+use p521::NistP521;
+use rand::rngs::OsRng;
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+
+use crate::ciphersuite::OprfHash;
+use crate::envelope::NonceLen;
+use crate::hash::OutputSize;
+use crate::key_exchange::group::KeGroup;
+use crate::key_exchange::tripledh::{DiffieHellman, TripleDh};
+use crate::keypair::{KeyPair, PublicKey};
+use crate::ksf::Identity;
+use crate::opaque::MaskedResponseLen;
+use crate::{
+    CipherSuite, ClientLogin, ClientLoginFinishParameters, ClientLoginStartResult,
+    ClientRegistration, ClientRegistrationFinishParameters, ClientRegistrationStartResult,
+    ServerLogin, ServerLoginStartParameters, ServerLoginStartResult, ServerRegistration,
+    ServerSetup,
+};
+#[cfg(all(feature = "curve25519", feature = "ristretto255"))]
+use crate::{Curve25519, Ristretto255};
+
+#[test]
+fn p256() {
+    struct Suite;
+
+    impl CipherSuite for Suite {
+        type OprfCs = NistP256;
+        type KeGroup = NistP256;
+        type KeyExchange = TripleDh;
+        type Ksf = Identity;
+    }
+
+    test::<Suite>(Mechanism::EccKeyPairGen, NistP256::OID);
+}
+
+#[test]
+fn p384() {
+    struct Suite;
+
+    impl CipherSuite for Suite {
+        type OprfCs = NistP384;
+        type KeGroup = NistP384;
+        type KeyExchange = TripleDh;
+        type Ksf = Identity;
+    }
+
+    test::<Suite>(Mechanism::EccKeyPairGen, NistP384::OID);
+}
+
+#[test]
+fn p521() {
+    struct Suite;
+
+    impl CipherSuite for Suite {
+        type OprfCs = NistP521;
+        type KeGroup = NistP521;
+        type KeyExchange = TripleDh;
+        type Ksf = Identity;
+    }
+
+    test::<Suite>(Mechanism::EccKeyPairGen, NistP521::OID);
+}
+
+#[test]
+#[cfg(all(feature = "curve25519", feature = "ristretto255"))]
+fn curve25519() {
+    struct Suite;
+
+    impl CipherSuite for Suite {
+        type OprfCs = Ristretto255;
+        type KeGroup = Curve25519;
+        type KeyExchange = TripleDh;
+        type Ksf = Identity;
+    }
+
+    test::<Suite>(
+        // This should be [`Mechanism::EccMontgomeryKeyPairGen`], but SoftHSM has an incorrect
+        // implementation. See https://github.com/softhsm/SoftHSMv2/issues/647.
+        Mechanism::EccEdwardsKeyPairGen,
+        ObjectIdentifier::new("1.3.101.110").unwrap(),
+    );
+}
+
+#[derive(Clone)]
+struct RemoteKey(ObjectHandle);
+
+trait Pkcs11DiffieHellman<KG: KeGroup> {
+    fn pkcs11_diffie_hellman(
+        &self,
+        server_pk: &PublicKey<KG>,
+        client_pk: &PublicKey<KG>,
+    ) -> GenericArray<u8, KG::PkLen>;
+}
+
+fn test<CS: CipherSuite<KeyExchange = TripleDh>>(mechanism: Mechanism, oid: ObjectIdentifier)
+where
+    RemoteKey: Pkcs11DiffieHellman<CS::KeGroup>,
+    <CS::KeGroup as KeGroup>::Sk: DiffieHellman<CS::KeGroup>,
+    // MaskedResponse: (Nonce + Hash) + KePk
+    NonceLen: Add<OutputSize<OprfHash<CS>>>,
+    Sum<NonceLen, OutputSize<OprfHash<CS>>>: ArrayLength<u8> + Add<<CS::KeGroup as KeGroup>::PkLen>,
+    MaskedResponseLen<CS>: ArrayLength<u8>,
+    // Ke1State: KeSk + Nonce
+    <CS::KeGroup as KeGroup>::SkLen: Add<NonceLen>,
+    Sum<<CS::KeGroup as KeGroup>::SkLen, NonceLen>: ArrayLength<u8>,
+    // Ke1Message: Nonce + KePk
+    NonceLen: Add<<CS::KeGroup as KeGroup>::PkLen>,
+    Sum<NonceLen, <CS::KeGroup as KeGroup>::PkLen>: ArrayLength<u8>,
+    // Ke2State: (Hash + Hash) + Hash
+    OutputSize<OprfHash<CS>>: Add<OutputSize<OprfHash<CS>>>,
+    Sum<OutputSize<OprfHash<CS>>, OutputSize<OprfHash<CS>>>:
+        ArrayLength<u8> + Add<OutputSize<OprfHash<CS>>>,
+    Sum<Sum<OutputSize<OprfHash<CS>>, OutputSize<OprfHash<CS>>>, OutputSize<OprfHash<CS>>>:
+        ArrayLength<u8>,
+    // Ke2Message: (Nonce + KePk) + Hash
+    NonceLen: Add<<CS::KeGroup as KeGroup>::PkLen>,
+    Sum<NonceLen, <CS::KeGroup as KeGroup>::PkLen>: ArrayLength<u8> + Add<OutputSize<OprfHash<CS>>>,
+    Sum<Sum<NonceLen, <CS::KeGroup as KeGroup>::PkLen>, OutputSize<OprfHash<CS>>>: ArrayLength<u8>,
+{
+    let (remote_key, pk) = pkcs11_generate_key_pair(mechanism, oid);
+
+    let keypair = KeyPair::new(RemoteKey(remote_key), pk);
+    let server_setup = ServerSetup::new_with_key_pair(&mut OsRng, keypair);
+
+    const PASSWORD: &str = "password";
+
+    let ClientRegistrationStartResult {
+        message,
+        state: client,
+    } = ClientRegistration::<CS>::start(&mut OsRng, PASSWORD.as_bytes()).unwrap();
+    let message = ServerRegistration::start(&server_setup, message, &[])
+        .unwrap()
+        .message;
+    let message = client
+        .finish(
+            &mut OsRng,
+            PASSWORD.as_bytes(),
+            message,
+            ClientRegistrationFinishParameters::default(),
+        )
+        .unwrap()
+        .message;
+    let file = ServerRegistration::finish(message);
+
+    let ClientLoginStartResult {
+        message,
+        state: client,
+    } = ClientLogin::<CS>::start(&mut OsRng, PASSWORD.as_bytes()).unwrap();
+    let builder = ServerLogin::builder(
+        &mut OsRng,
+        &server_setup,
+        Some(file),
+        message,
+        &[],
+        ServerLoginStartParameters::default(),
+    )
+    .unwrap();
+    let shared_secret = builder
+        .private_key()
+        .pkcs11_diffie_hellman(server_setup.keypair().public(), builder.data());
+
+    let ServerLoginStartResult {
+        message,
+        state: server,
+        ..
+    } = builder.clone().build(shared_secret).unwrap();
+
+    let message = client
+        .clone()
+        .finish(
+            PASSWORD.as_bytes(),
+            message,
+            ClientLoginFinishParameters::default(),
+        )
+        .map(|result| result.message);
+
+    message
+        .map(|message| server.finish(message).unwrap())
+        .unwrap();
+}
+
+static SESSION: LazyLock<Mutex<Session>> = LazyLock::new(|| {
+    let module = env::var("PKCS11_MODULE").expect("`PKCS11_MODULE` environment variable");
+    let pkcs11 = Pkcs11::new(module).unwrap();
+    pkcs11.initialize(CInitializeArgs::OsThreads).unwrap();
+
+    let slot = pkcs11.get_slots_with_token().unwrap()[0];
+
+    let so_pin = AuthPin::new("abcdef".into());
+    pkcs11.init_token(slot, &so_pin, "Test Token").unwrap();
+
+    let user_pin = AuthPin::new("fedcba".into());
+
+    {
+        let session = pkcs11.open_rw_session(slot).unwrap();
+        session.login(UserType::So, Some(&so_pin)).unwrap();
+        session.init_pin(&user_pin).unwrap();
+    }
+
+    let session = pkcs11.open_rw_session(slot).unwrap();
+    session.login(UserType::User, Some(&user_pin)).unwrap();
+
+    Mutex::new(session)
+});
+
+fn pkcs11_generate_key_pair<KG: KeGroup>(
+    mechanism: Mechanism,
+    oid: ObjectIdentifier,
+) -> (ObjectHandle, PublicKey<KG>) {
+    let session = SESSION.lock().unwrap();
+    let (pk, remote_key) = session
+        .generate_key_pair(
+            &mechanism,
+            &[
+                Attribute::Token(false),
+                Attribute::EcParams(oid.to_der().unwrap()),
+            ],
+            &[Attribute::Token(false), Attribute::Derive(true)],
+        )
+        .unwrap();
+
+    let Attribute::EcPoint(pk) = session
+        .get_attributes(pk, &[AttributeType::EcPoint])
+        .unwrap()
+        .pop()
+        .unwrap()
+    else {
+        unreachable!()
+    };
+    drop(session);
+
+    let pk = OctetString::from_der(&pk).unwrap();
+    let pk = PublicKey::deserialize(pk.as_bytes()).unwrap();
+
+    (remote_key, pk)
+}
+
+impl Pkcs11DiffieHellman<NistP256> for RemoteKey {
+    fn pkcs11_diffie_hellman(
+        &self,
+        server_pk: &PublicKey<NistP256>,
+        client_pk: &PublicKey<NistP256>,
+    ) -> GenericArray<u8, <NistP256 as KeGroup>::PkLen> {
+        ec_pkcs_11_derive_secret::<NistP256>(self.0, server_pk, client_pk)
+    }
+}
+
+impl Pkcs11DiffieHellman<NistP384> for RemoteKey {
+    fn pkcs11_diffie_hellman(
+        &self,
+        server_pk: &PublicKey<NistP384>,
+        client_pk: &PublicKey<NistP384>,
+    ) -> GenericArray<u8, <NistP384 as KeGroup>::PkLen> {
+        ec_pkcs_11_derive_secret::<NistP384>(self.0, server_pk, client_pk)
+    }
+}
+
+impl Pkcs11DiffieHellman<NistP521> for RemoteKey {
+    fn pkcs11_diffie_hellman(
+        &self,
+        server_pk: &PublicKey<NistP521>,
+        client_pk: &PublicKey<NistP521>,
+    ) -> GenericArray<u8, <NistP521 as KeGroup>::PkLen> {
+        ec_pkcs_11_derive_secret::<NistP521>(self.0, server_pk, client_pk)
+    }
+}
+
+#[cfg(all(feature = "curve25519", feature = "ristretto255"))]
+impl Pkcs11DiffieHellman<Curve25519> for RemoteKey {
+    fn pkcs11_diffie_hellman(
+        &self,
+        _: &PublicKey<Curve25519>,
+        pk: &PublicKey<Curve25519>,
+    ) -> GenericArray<u8, <Curve25519 as KeGroup>::PkLen> {
+        let shared_secret = pkcs11_derive_secret(self.0, &pk.serialize());
+
+        GenericArray::clone_from_slice(&shared_secret)
+    }
+}
+
+fn pkcs11_derive_secret(sk: ObjectHandle, pk: &[u8]) -> Vec<u8> {
+    let session = SESSION.lock().unwrap();
+    let shared_secret = session
+        .derive_key(
+            &Mechanism::Ecdh1Derive(Ecdh1DeriveParams::new(EcKdf::null(), pk)),
+            sk,
+            &[
+                Attribute::Token(false),
+                Attribute::KeyType(KeyType::GENERIC_SECRET),
+                Attribute::Class(ObjectClass::SECRET_KEY),
+                Attribute::Extractable(true),
+            ],
+        )
+        .unwrap();
+
+    let Attribute::Value(shared_secret) = session
+        .get_attributes(shared_secret, &[AttributeType::Value])
+        .unwrap()
+        .pop()
+        .unwrap()
+    else {
+        unreachable!()
+    };
+    drop(session);
+
+    shared_secret
+}
+
+fn ec_pkcs_11_derive_secret<KG>(
+    server_sk: ObjectHandle,
+    server_pk: &PublicKey<KG>,
+    client_pk: &PublicKey<KG>,
+) -> GenericArray<u8, <KG as KeGroup>::PkLen>
+where
+    KG: KeGroup<Pk = ProjectivePoint<KG>> + CurveArithmetic,
+    AffinePoint<KG>: DecompressPoint<KG> + ToEncodedPoint<KG>,
+    FieldBytesSize<KG>: ModulusSize,
+{
+    let client_pk_point = client_pk.to_group_type();
+    let client_pk = client_pk.serialize();
+    let client_pk = OctetStringRef::new(&client_pk).unwrap();
+    let client_pk = client_pk.to_der().unwrap();
+
+    let shared_secret_bytes = pkcs11_derive_secret(server_sk, &client_pk);
+    let shared_secret_point = AffinePoint::<KG>::decompress(
+        &GenericArray::clone_from_slice(&shared_secret_bytes),
+        Choice::from(0),
+    )
+    .unwrap();
+    let mut shared_secret = GenericArray::default();
+    shared_secret[1..].copy_from_slice(&shared_secret_bytes);
+
+    let shifted_client_pk = client_pk_point + ProjectivePoint::<KG>::generator();
+    let shifted_client_pk = shifted_client_pk.to_affine().to_encoded_point(true);
+    let shifted_client_pk = OctetStringRef::new(shifted_client_pk.as_bytes()).unwrap();
+    let shifted_client_pk = shifted_client_pk.to_der().unwrap();
+
+    let check_point = pkcs11_derive_secret(server_sk, &shifted_client_pk);
+
+    let shifted_server_pk = server_pk.to_group_type() + shared_secret_point;
+    let shifted_server_pk = shifted_server_pk.to_affine();
+
+    let tag = u8::conditional_select(
+        &(Tag::CompressedEvenY as u8),
+        &(Tag::CompressedOddY as u8),
+        check_point.ct_ne(&shifted_server_pk.x()),
+    );
+    shared_secret[0] = tag;
+
+    shared_secret
+}


### PR DESCRIPTION
I apologize in advance to squash so many unrelated changes into a single commit and PR!
Let me know if you want me to split this up into multiple commits or PRs and I'm happy to put in the work!

---

The `SecretKey` trait has one big limitation: it doesn't support async operations. This became especially important with the advent of [cloud HSMs](https://aws.amazon.com/kms), where operations can even happen over the Internet between different services.

The intuitive solution would have been to introduce another trait: `SecretKeyAsync`, or just add another method to `SecretKey` and users can just slap `unimplemented!()` in the synchronous method. We can still do this with actually some minor changes, but I instead opted for a different solution: removing the `SecretKey` trait entirely.

Instead, there is now a different API flow available for remote key users:
- `ServerLogin::builder() -> ServerLoginBuilder`
- `ServerLoginBuilder::private_key()` to get a handle to the users secret key.
- `ServerLoginBuilder::data()` to get the clients ephemeral public key.
- At this point, the user can do their HSM operations any way they want without being limited by our API.
- `ServerLoginBuilder::build() -> ServerLogin` supplying the computed shared secret.

The normal API flow stays the same with `ServerLogin::start()`.

One more point to add here: until now the Diffie-Hellman operation was quite tightly coupled with the rest of the API instead of being limited to the key exchange. E.g. `Group` and `SecretKey` implementations still have to provide it. This wasn't a problem until now because we only support the 3DH key exchange protocol.

However, I intend to add support for SIGMA-I next. The big reason is that apart from AWS I don't know of any cloud HSM that supports ECDH, instead they only support signing, which SIGMA-I would facilitate. Therefor it was important for me to finally make this separation to allow us to add new key exchange methods without forcing users to slap `unimplemented!()` everywhere and to retain compile-time checks.

The crux here being is that there is no way to enforce a trait implementation on a generic that isn't part of the trait enforcing it. So `TripleDh` can't enforce a trait (e.g. `DiffieHellman`) on `S` (`SecretKey`), because `S` isn't a generic on either `KeyExchange` or `TripleDh`. Making it a generic on either one would force `CipherSuite`s to be bound to a specific type `S` and limit its flexibility.

Instead, we can now add associated type to `KeyExchange` that determine the type users have to be able extract and perform computation on dynamically through `ServerLoginBuilder::data()`. E.g. `TripleDh` will return the clients ephemeral public key to compute the shared secret with DH and SIGMA-I will return data to sign with the server secret key.

This might have been solvable with a trait if Rust supported [associated traits](https://github.com/rust-lang/rfcs/issues/2190).

But I don't want to somehow undersell the new API. While its usage is only slightly more verbose then letting the user implement a trait, it allows for much more flexible. The main inspiration was [Rustl's `Acceptor` API](https://docs.rs/rustls/0.23.26/rustls/server/struct.Acceptor.html), which was an answer to a similar problem.

---

### Major Changes

- A new test suite actually testing against SoftHSM to verify our API makes sense and works in practice.
- A new trait `DiffieHellman`, which is required for `CipherSuite::KeGroup::Sk` by `TripleDh`. This splits off the original `KeGroup::diffie_hellman()` function into its own trait which is required from any `KeGroup` wanting to be compatible with `TripleDh`.
- Building `KeyPair` with a remote key in practice was quite difficult, requiring to operate the HSM from inside the trait method without being able to pass in an e.g. HSM connection. In practice, the public key was stored as part of the secret key to return when required, duplicating the data.
  - `KeyPair::new()`, `PrivateKey::deserialize()` and `PrivateKey::public_key()` replaces `KeyPair::from_private_key_slice()` and `KeyPair::from_private_key()`.
  - Introduce `PrivateKeySerialization`, to facilitate `KeyPair::de/serialize()` and `ServerSetup::de/serialize()`.
- `ProtocolError::Custom` is now only present in `PrivateKeySerialization`, making error types more compatible with each other.

### Internal Changes

- Introduce associated types to `KeyExchange` to facilitate the builder API:
  - `KE2Builder` holds the data in the builder required by the `KeyExchange` to finish building `KE2Message`.
  - `KE2BuilderData` is the data the user is required to process returned by `ServerLoginBuilder::data()`. For 3DH this is the clients ephemeral public key for the DH key exchange.
  - `KE2BuilderInput` is the data the user is required to supply to `ServerLoginBuilder::build()`. For 3DH this is the shared secret computed by the user with the DH key exchange.
- Split `KeyExchange::generate_ke2()` into multiple parts:
  - `ke2_builder()` creates the `KE2Builder`. Holds all the computation results for `KE2Message` apart from anything requiring the servers secret key.
  - `generate_ke2_input()` computes the `KE2BuilderInput` in the regular API flow when the secret key is available.
  - `build_ke2()` finally generates the `KE2Message` with the `KE2BuilderInput`.


### Minor Changes

- Add `PublicKey::to_group_type()`, otherwise real HSM implementations had to de/serialize received `PublicKey`s to actually work with the data.
- Wrap `ServerSetup::oprf_seed` in `Zeroizing`.
- `CipherSuite::KeGroup` now requires `'static`. This was needed to add a lifetime to `KeyExchange::KE2BuilderData`.
- Move `InternalError::Custom` and `InternalError::SizeError` to `ProtocolError`, as they aren't internal errors.
- Remove `InternalError::InvalidByteSequence` and `InternalError::PointError`, as they are unused.

---

~~This is currently based on https://github.com/RustCrypto/formats/pull/1765 and https://github.com/ModProg/derive-where/pull/109. So we might want to wait until they release or I can update `Cargo.toml` in a follow-up PR.~~
Both got a new release.