### PR TITLE
Remote OPRF Seed Support

### DIFF
--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -23,20 +23,20 @@ use crate::key_exchange::tripledh::DiffieHellman;
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(bound(
-        deserialize = "S: serde::Deserialize<'de>",
-        serialize = "S: serde::Serialize"
+        deserialize = "SK: serde::Deserialize<'de>",
+        serialize = "SK: serde::Serialize"
     ))
 )]
 #[derive_where(Clone)]
-#[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; KG::Pk, S)]
-pub struct KeyPair<KG: KeGroup, S: Clone = PrivateKey<KG>> {
+#[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; KG::Pk, SK)]
+pub struct KeyPair<KG: KeGroup, SK: Clone = PrivateKey<KG>> {
     pk: PublicKey<KG>,
-    sk: S,
+    sk: SK,
 }
 
-impl<KG: KeGroup, S: Clone> KeyPair<KG, S> {
+impl<KG: KeGroup, SK: Clone> KeyPair<KG, SK> {
     /// Creates a new [`KeyPair`] from the given keys.
-    pub fn new(sk: S, pk: PublicKey<KG>) -> Self {
+    pub fn new(sk: SK, pk: PublicKey<KG>) -> Self {
         Self { pk, sk }
     }
 
@@ -46,7 +46,7 @@ impl<KG: KeGroup, S: Clone> KeyPair<KG, S> {
     }
 
     /// The private key component
-    pub fn private(&self) -> &S {
+    pub fn private(&self) -> &SK {
         &self.sk
     }
 }
@@ -171,9 +171,9 @@ impl<'de, KG: KeGroup> serde::Deserialize<'de> for PrivateKey<KG> {
 
 #[cfg(feature = "serde")]
 impl<KG: KeGroup> serde::Serialize for PrivateKey<KG> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<SK>(&self, serializer: SK) -> Result<SK::Ok, SK::Error>
     where
-        S: serde::Serializer,
+        SK: serde::Serializer,
     {
         KG::serialize_sk(self.0).serialize(serializer)
     }
@@ -217,9 +217,9 @@ impl<'de, KG: KeGroup> serde::Deserialize<'de> for PublicKey<KG> {
 
 #[cfg(feature = "serde")]
 impl<KG: KeGroup> serde::Serialize for PublicKey<KG> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<SK>(&self, serializer: SK) -> Result<SK::Ok, SK::Error>
     where
-        S: serde::Serializer,
+        SK: serde::Serializer,
     {
         KG::serialize_pk(self.0).serialize(serializer)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1192,7 +1192,7 @@ pub use crate::messages::{
 pub use crate::opaque::{
     ClientLogin, ClientLoginFinishParameters, ClientLoginFinishResult, ClientLoginStartResult,
     ClientRegistration, ClientRegistrationFinishParameters, ClientRegistrationFinishResult,
-    ClientRegistrationStartResult, Identifiers, ServerLogin, ServerLoginFinishResult,
-    ServerLoginStartParameters, ServerLoginStartResult, ServerRegistration, ServerRegistrationLen,
-    ServerRegistrationStartResult, ServerSetup,
+    ClientRegistrationStartResult, Identifiers, KeyMaterialInfo, ServerLogin,
+    ServerLoginFinishResult, ServerLoginStartParameters, ServerLoginStartResult,
+    ServerRegistration, ServerRegistrationLen, ServerRegistrationStartResult, ServerSetup,
 };

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -115,21 +115,21 @@ pub struct CredentialRequest<CS: CipherSuite> {
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(bound(
-        deserialize = "S: serde::Deserialize<'de>, <CS::KeyExchange as KeyExchange<OprfHash<CS>, \
+        deserialize = "SK: serde::Deserialize<'de>, <CS::KeyExchange as KeyExchange<OprfHash<CS>, \
                        CS::KeGroup>>::KE2Builder: serde::Deserialize<'de>",
-        serialize = "S: serde::Serialize, <CS::KeyExchange as KeyExchange<OprfHash<CS>, \
+        serialize = "SK: serde::Serialize, <CS::KeyExchange as KeyExchange<OprfHash<CS>, \
                      CS::KeGroup>>::KE2Builder: serde::Serialize"
     ))
 )]
 #[derive_where(Clone)]
 #[derive_where(
     Debug, Eq, PartialEq;
-    S,
+    SK,
     voprf::EvaluationElement<CS::OprfCs>,
     <CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE2Builder,
 )]
-pub struct ServerLoginBuilder<CS: CipherSuite, S: Clone> {
-    pub(crate) server_s_sk: S,
+pub struct ServerLoginBuilder<CS: CipherSuite, SK: Clone> {
+    pub(crate) server_s_sk: SK,
     pub(crate) evaluation_element: voprf::EvaluationElement<CS::OprfCs>,
     pub(crate) masking_nonce: Zeroizing<GenericArray<u8, NonceLen>>,
     pub(crate) masked_response: MaskedResponse<CS>,
@@ -138,7 +138,7 @@ pub struct ServerLoginBuilder<CS: CipherSuite, S: Clone> {
     pub(crate) ke2_builder: <CS::KeyExchange as KeyExchange<OprfHash<CS>, CS::KeGroup>>::KE2Builder,
 }
 
-impl<CS: CipherSuite, S: Clone> ServerLoginBuilder<CS, S> {
+impl<CS: CipherSuite, SK: Clone> ServerLoginBuilder<CS, SK> {
     /// The returned data here has to be processed and the result given as an
     /// input to [`ServerLoginBuilder::build()`]. To understand what kind of
     /// output is expected here and how to process it, refer to the
@@ -150,7 +150,7 @@ impl<CS: CipherSuite, S: Clone> ServerLoginBuilder<CS, S> {
     }
 
     /// The handle to the corresponding [`ServerSetup`]s private key.
-    pub fn private_key(&self) -> &S {
+    pub fn private_key(&self) -> &SK {
         &self.server_s_sk
     }
 
@@ -325,9 +325,9 @@ impl<CS: CipherSuite> RegistrationUpload<CS> {
     }
 
     // Creates a dummy instance used for faking a [CredentialResponse]
-    pub(crate) fn dummy<R: RngCore + CryptoRng, S: Clone>(
+    pub(crate) fn dummy<R: RngCore + CryptoRng, SK: Clone, OS: Clone>(
         rng: &mut R,
-        server_setup: &ServerSetup<CS, S>,
+        server_setup: &ServerSetup<CS, SK, OS>,
     ) -> Self {
         let mut masking_key = Output::<OprfHash<CS>>::default();
         rng.fill_bytes(&mut masking_key);


### PR DESCRIPTION
This PR expands the API to enable storing the OPRF seed on an HSM. The operation that is externalized here is the HDKF expand operation in `CreateRegistrationResponse` and `CreateCredentialResponse`, which is used to derive the per-user OPRF key. The API and documentation call the output of the HKDF operation "key material".

The change is rather small and the API flow only changes minimally. Instead of calling `ServerRegistration::start()`, users have to call `ServerSetup::key_material_info()` first, generate the key material and then call `ServerRegistration::start_with_key_material()`. The same with `ServerLogin::builder()`, users generate the key material and then call `ServerLogin::builder_with_key_material()`.

Notably the current API does not allow to have a remote OPRF seed but a local private key. My assumption is that it is unlikely anybody would run a setup like that.

I should also mention that I'm not aware of any HSM supporting HKDF, not even SoftHSM. PKCS#11 itself only received support in v3 AFAIK. Instead users are expected to implement HKDF by hand and use the HSMs HMAC operation, which almost all HSMs out there support. This still keeps the OPRF seed protected.

Changes:
- `ServerSetup::new_with_key_pair_and_seed()` to build a `SeverSetup` from a remote private key *and* OPRF seed.
- `ServerSetup::key_material_info()` returns a `KeyMaterialInfo`, containing all necessary information to generate the key material needed via HKDF.
- `OprfSeedSerialization`, the equivalent of `PrivateKeySerialization` too facilitate `ServerSetup::de/serialize()` with a remote OPRF seed.
- `ServerRegistration::start_with_key_material()`, the equivalent of `ServerRegistration::start()` but with a remote OPRF seed.
- `ServerLogin::builder_with_key_material()`, the equivalent of `ServerLogin::builder()` but with a remote OPRF seed.
- Adjusted the remote key test to make use of the new functionality.

Based on #371.