### PR TITLE
Enable `curve25519-dalek/serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,13 @@ curve25519 = ["dep:curve25519-dalek"]
 default = ["ristretto255-voprf", "serde"]
 ristretto255 = ["dep:curve25519-dalek", "voprf/ristretto255"]
 ristretto255-voprf = ["ristretto255", "voprf/ristretto255-ciphersuite"]
-serde = ["dep:serde", "generic-array/serde", "voprf/serde", "zeroize/serde"]
+serde = [
+  "dep:serde",
+  "curve25519-dalek?/serde",
+  "generic-array/serde",
+  "voprf/serde",
+  "zeroize/serde",
+]
 std = ["dep:getrandom"]
 
 [dependencies]


### PR DESCRIPTION
Currently users would have to depend manually on `curve25519-dalek` to enable Serde.

This seems to have been lost back in https://github.com/facebook/opaque-ke/pull/250, I suspect because enabling crate features on optional dependencies with `?` wasn't available back then.