### PR TITLE
Add copyright header to `remote_key` test

### DIFF
--- a/src/tests/remote_key.rs
+++ b/src/tests/remote_key.rs
@@ -1,3 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is dual-licensed under either the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree or the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree. You may select, at your option, one of the above-listed
+// licenses.
+
 use std::env;
 use std::ops::Add;
 use std::sync::{LazyLock, Mutex};


### PR DESCRIPTION
As requested in https://github.com/facebook/opaque-ke/pull/376#issuecomment-2824840072.
This was missed in #371.