### PR TITLE
Move Serde De/Serialization to `Group` Implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = [
   "curve25519-dalek?/serde",
   "ecdsa?/serde",
   "ed25519-dalek?/serde",
+  "elliptic-curve/serde",
   "generic-array/serde",
   "voprf/serde",
   "zeroize/serde",

--- a/src/key_exchange/group/curve25519.rs
+++ b/src/key_exchange/group/curve25519.rs
@@ -80,6 +80,7 @@ impl Group for Curve25519 {
 }
 
 /// Curve25519 scalar.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Zeroize)]
 pub struct Scalar([u8; 32]);
 

--- a/src/key_exchange/group/ed25519.rs
+++ b/src/key_exchange/group/ed25519.rs
@@ -297,7 +297,7 @@ impl serde::Serialize for VerifyingKey {
     }
 }
 
-/// Ed25519 siging key.
+/// Ed25519 signing key.
 // We store the `ExpandedSecret` in memory to avoid computing it on demand and then discarding it
 // again.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Zeroize)]

--- a/src/key_exchange/group/ed25519.rs
+++ b/src/key_exchange/group/ed25519.rs
@@ -46,15 +46,9 @@ impl Group for Ed25519 {
     }
 
     fn deserialize_take_pk(bytes: &mut &[u8]) -> Result<Self::Pk, ProtocolError> {
-        let compressed = bytes
-            .take_array("public key")
-            .map(|bytes| CompressedEdwardsY(bytes.into()))?;
+        let bytes = bytes.take_array("public key")?;
 
-        if let Some(point) = compressed.decompress().filter(|point| !point.is_identity()) {
-            Ok(VerifyingKey { point, compressed })
-        } else {
-            Err(ProtocolError::SerializationError)
-        }
+        VerifyingKey::from_bytes(bytes.into())
     }
 
     fn random_sk<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Sk {
@@ -80,108 +74,6 @@ impl Group for Ed25519 {
         Ok(SigningKey::from_bytes(
             bytes.take_array("secret key")?.into(),
         ))
-    }
-}
-
-/// Ed25519 verifying key.
-// `ed25519_dalek::VerifyingKey` doesn't implement `Zeroize`.
-// TODO: remove after https://github.com/dalek-cryptography/curve25519-dalek/pull/747.
-// Required for manual implementation of EdDSA.
-// TODO: remove after https://github.com/dalek-cryptography/curve25519-dalek/pull/556.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Zeroize)]
-pub struct VerifyingKey {
-    point: EdwardsPoint,
-    compressed: CompressedEdwardsY,
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for VerifyingKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use serde::de::Error;
-
-        Ed25519::deserialize_take_pk(
-            &mut (GenericArray::<_, <Ed25519 as Group>::PkLen>::deserialize(deserializer)?
-                .as_slice()),
-        )
-        .map_err(D::Error::custom)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for VerifyingKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        Ed25519::serialize_pk(*self).serialize(serializer)
-    }
-}
-
-/// Ed25519 siging key.
-// We store the `ExpandedSecret` in memory to avoid computing it on demand and then discarding it
-// again.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Zeroize)]
-pub struct SigningKey {
-    // `ed25519_dalek::SigningKey` doesn't implement `Zeroize`. See
-    // https://github.com/dalek-cryptography/curve25519-dalek/pull/747
-    // Required for manual implementation of EdDSA.
-    // TODO: remove after https://github.com/dalek-cryptography/curve25519-dalek/pull/556.
-    sk: SecretKey,
-    verifying_key: VerifyingKey,
-    // `ed25519_dalek::ExpandedSecret` doesn't implement traits we need. See
-    // TODO: remove after https://github.com/dalek-cryptography/curve25519-dalek/pull/748 and
-    // https://github.com/dalek-cryptography/curve25519-dalek/pull/747.
-    scalar: Scalar,
-    hash_prefix: [u8; 32],
-}
-
-impl SigningKey {
-    fn from_bytes(sk: [u8; 32]) -> Self {
-        let ExpandedSecretKey {
-            scalar,
-            hash_prefix,
-        } = ExpandedSecretKey::from(&sk);
-        let point = EdwardsPoint::mul_base(&scalar);
-        let verifying_key = VerifyingKey {
-            point,
-            compressed: point.compress(),
-        };
-
-        SigningKey {
-            sk,
-            verifying_key,
-            scalar,
-            hash_prefix,
-        }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for SigningKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use serde::de::Error;
-
-        Ed25519::deserialize_take_sk(
-            &mut (GenericArray::<_, <Ed25519 as Group>::SkLen>::deserialize(deserializer)?
-                .as_slice()),
-        )
-        .map_err(D::Error::custom)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for SigningKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        Ed25519::serialize_sk(*self).serialize(serializer)
     }
 }
 
@@ -330,8 +222,175 @@ fn verify<'a>(
     }
 }
 
+/// Ed25519 verifying key.
+// `ed25519_dalek::VerifyingKey` doesn't implement `Zeroize`.
+// TODO: remove after https://github.com/dalek-cryptography/curve25519-dalek/pull/747.
+// Required for manual implementation of EdDSA.
+// TODO: remove after https://github.com/dalek-cryptography/curve25519-dalek/pull/556.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Zeroize)]
+pub struct VerifyingKey {
+    point: EdwardsPoint,
+    compressed: CompressedEdwardsY,
+}
+
+impl VerifyingKey {
+    fn from_bytes(bytes: [u8; 32]) -> Result<Self, ProtocolError> {
+        let compressed = CompressedEdwardsY(bytes);
+
+        if let Some(point) = compressed.decompress().filter(|point| !point.is_identity()) {
+            Ok(Self { point, compressed })
+        } else {
+            Err(ProtocolError::SerializationError)
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for VerifyingKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use core::fmt::{self, Formatter};
+
+        use serde::de::{Deserialize, Deserializer, Error, SeqAccess, Visitor};
+
+        struct VerifyingKeyVisitor;
+
+        impl<'de> Visitor<'de> for VerifyingKeyVisitor {
+            type Value = VerifyingKey;
+
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                Formatter::write_str(formatter, "tuple struct VerifyingKey")
+            }
+
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let compressed = CompressedEdwardsY::deserialize(deserializer)?;
+                VerifyingKey::from_bytes(compressed.0).map_err(Error::custom)
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let compressed: CompressedEdwardsY = seq.next_element()?.ok_or_else(|| {
+                    Error::invalid_length(0, &"tuple struct VerifyingKey with 1 element")
+                })?;
+                VerifyingKey::from_bytes(compressed.0).map_err(Error::custom)
+            }
+        }
+
+        deserializer.deserialize_newtype_struct("VerifyingKey", VerifyingKeyVisitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for VerifyingKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_newtype_struct("VerifyingKey", &self.compressed)
+    }
+}
+
+/// Ed25519 siging key.
+// We store the `ExpandedSecret` in memory to avoid computing it on demand and then discarding it
+// again.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Zeroize)]
+pub struct SigningKey {
+    // `ed25519_dalek::SigningKey` doesn't implement `Zeroize`. See
+    // https://github.com/dalek-cryptography/curve25519-dalek/pull/747
+    // Required for manual implementation of EdDSA.
+    // TODO: remove after https://github.com/dalek-cryptography/curve25519-dalek/pull/556.
+    sk: SecretKey,
+    verifying_key: VerifyingKey,
+    // `ed25519_dalek::ExpandedSecret` doesn't implement traits we need. See
+    // TODO: remove after https://github.com/dalek-cryptography/curve25519-dalek/pull/748 and
+    // https://github.com/dalek-cryptography/curve25519-dalek/pull/747.
+    scalar: Scalar,
+    hash_prefix: [u8; 32],
+}
+
+impl SigningKey {
+    fn from_bytes(sk: [u8; 32]) -> Self {
+        let ExpandedSecretKey {
+            scalar,
+            hash_prefix,
+        } = ExpandedSecretKey::from(&sk);
+        let point = EdwardsPoint::mul_base(&scalar);
+        let verifying_key = VerifyingKey {
+            point,
+            compressed: point.compress(),
+        };
+
+        SigningKey {
+            sk,
+            verifying_key,
+            scalar,
+            hash_prefix,
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for SigningKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use core::fmt::{self, Formatter};
+
+        use serde::de::{Deserialize, Deserializer, Error, SeqAccess, Visitor};
+
+        struct SigningKeyVisitor;
+
+        impl<'de> Visitor<'de> for SigningKeyVisitor {
+            type Value = SigningKey;
+
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                Formatter::write_str(formatter, "tuple struct SigningKey")
+            }
+
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let sk = Scalar::deserialize(deserializer)?;
+                Ok(SigningKey::from_bytes(sk.to_bytes()))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let sk: Scalar = seq.next_element()?.ok_or_else(|| {
+                    Error::invalid_length(0, &"tuple struct SigningKey with 1 element")
+                })?;
+                Ok(SigningKey::from_bytes(sk.to_bytes()))
+            }
+        }
+
+        deserializer.deserialize_newtype_struct("SigningKey", SigningKeyVisitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for SigningKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_newtype_struct("SigningKey", &self.sk)
+    }
+}
+
 /// Ed25519 Signature.
 // `ed25519_dalek::Signature` doesn't implement validation with Serde de/serialization.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[allow(non_snake_case)]
 pub struct Signature {
@@ -359,31 +418,6 @@ impl Signature {
 
     fn serialize(&self) -> GenericArray<u8, U64> {
         GenericArray::from(self.R.0).concat(GenericArray::from(self.s.to_bytes()))
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for Signature {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use serde::de::Error;
-
-        Signature::deserialize_take(
-            &mut (GenericArray::<_, U64>::deserialize(deserializer)?.as_slice()),
-        )
-        .map_err(D::Error::custom)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for Signature {
-    fn serialize<SK>(&self, serializer: SK) -> Result<SK::Ok, SK::Error>
-    where
-        SK: serde::Serializer,
-    {
-        self.serialize().serialize(serializer)
     }
 }
 

--- a/src/key_exchange/group/ed25519.rs
+++ b/src/key_exchange/group/ed25519.rs
@@ -94,6 +94,32 @@ pub struct VerifyingKey {
     compressed: CompressedEdwardsY,
 }
 
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for VerifyingKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        Ed25519::deserialize_take_pk(
+            &mut (GenericArray::<_, <Ed25519 as Group>::PkLen>::deserialize(deserializer)?
+                .as_slice()),
+        )
+        .map_err(D::Error::custom)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for VerifyingKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Ed25519::serialize_pk(*self).serialize(serializer)
+    }
+}
+
 /// Ed25519 siging key.
 // We store the `ExpandedSecret` in memory to avoid computing it on demand and then discarding it
 // again.
@@ -130,6 +156,32 @@ impl SigningKey {
             scalar,
             hash_prefix,
         }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for SigningKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        Ed25519::deserialize_take_sk(
+            &mut (GenericArray::<_, <Ed25519 as Group>::SkLen>::deserialize(deserializer)?
+                .as_slice()),
+        )
+        .map_err(D::Error::custom)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for SigningKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Ed25519::serialize_sk(*self).serialize(serializer)
     }
 }
 

--- a/src/key_exchange/shared.rs
+++ b/src/key_exchange/shared.rs
@@ -57,7 +57,10 @@ pub trait DiffieHellman<G: Group> {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "")
+    serde(bound(
+        deserialize = "G::Sk: serde::Deserialize<'de>",
+        serialize = "G::Sk: serde::Serialize"
+    ))
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; G::Sk)]
@@ -70,7 +73,10 @@ pub struct Ke1State<G: Group> {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "")
+    serde(bound(
+        deserialize = "G::Pk: serde::Deserialize<'de>",
+        serialize = "G::Pk: serde::Serialize"
+    ))
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; G::Pk)]

--- a/src/key_exchange/sigma_i/ecdsa.rs
+++ b/src/key_exchange/sigma_i/ecdsa.rs
@@ -136,7 +136,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "")
+    serde(bound = "", transparent)
 )]
 pub struct Signature<G: CurveArithmetic + PrimeCurve>(pub ecdsa::Signature<G>)
 where

--- a/src/key_exchange/sigma_i/mod.rs
+++ b/src/key_exchange/sigma_i/mod.rs
@@ -144,10 +144,14 @@ pub trait SignatureProtocol {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound(deserialize = "'de: 'a", serialize = ""))
+    serde(bound(
+        deserialize = "'de: 'a, <KeGroup<CS> as Group>::Pk: serde::Deserialize<'de>, KE::Pk: \
+                       serde::Deserialize<'de>",
+        serialize = "<KeGroup<CS> as Group>::Pk: serde::Serialize, KE::Pk: serde::Serialize"
+    ))
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
-#[derive_where(Debug, Eq, Hash, PartialEq; PublicKey<KeGroup<CS>>, PublicKey<KE>)]
+#[derive_where(Debug, Eq, Hash, PartialEq; <KeGroup<CS> as Group>::Pk, KE::Pk)]
 pub struct Ke2Builder<'a, CS: CipherSuite, KE: Group> {
     transcript: Message<'a, CS, KE>,
     server_nonce: GenericArray<u8, NonceLen>,
@@ -166,8 +170,10 @@ pub struct Ke2Builder<'a, CS: CipherSuite, KE: Group> {
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(bound(
-        deserialize = "SIG::VerifyState<CS, KE>: serde::Deserialize<'de>",
-        serialize = "SIG::VerifyState<CS, KE>: serde::Serialize"
+        deserialize = "<SIG::Group as Group>::Pk: serde::Deserialize<'de>, SIG::VerifyState<CS, \
+                       KE>: serde::Deserialize<'de>",
+        serialize = "<SIG::Group as Group>::Pk: serde::Serialize, SIG::VerifyState<CS, KE>: \
+                     serde::Serialize"
     ))
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
@@ -184,8 +190,8 @@ pub struct Ke2State<CS: CipherSuite, SIG: SignatureProtocol, KE: Group> {
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(bound(
-        deserialize = "SIG::Signature: serde::Deserialize<'de>",
-        serialize = "SIG::Signature: serde::Serialize"
+        deserialize = "KE::Pk: serde::Deserialize<'de>, SIG::Signature: serde::Deserialize<'de>",
+        serialize = "KE::Pk: serde::Serialize, SIG::Signature: serde::Serialize"
     ))
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]

--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -95,7 +95,10 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "")
+    serde(bound(
+        deserialize = "G::Pk: serde::Deserialize<'de>",
+        serialize = "G::Pk: serde::Serialize"
+    ))
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; G::Pk)]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -58,7 +58,10 @@ pub struct RegistrationRequest<CS: CipherSuite> {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "")
+    serde(bound(
+        deserialize = "<KeGroup<CS> as Group>::Pk: serde::Deserialize<'de>",
+        serialize = "<KeGroup<CS> as Group>::Pk: serde::Serialize"
+    ))
 )]
 #[derive_where(Clone)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; voprf::EvaluationElement<CS::OprfCs>, <KeGroup<CS> as Group>::Pk)]
@@ -74,7 +77,10 @@ pub struct RegistrationResponse<CS: CipherSuite> {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "")
+    serde(bound(
+        deserialize = "<KeGroup<CS> as Group>::Pk: serde::Deserialize<'de>",
+        serialize = "<KeGroup<CS> as Group>::Pk: serde::Serialize"
+    ))
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; <KeGroup<CS> as Group>::Pk)]

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -62,8 +62,11 @@ const STR_OPAQUE_DERIVE_KEY_PAIR: &[u8; 20] = b"OPAQUE-DeriveKeyPair";
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(bound(
-        deserialize = "SK: serde::Deserialize<'de>, OS: serde::Deserialize<'de>",
-        serialize = "SK: serde::Serialize, OS: serde::Serialize"
+        deserialize = "<KeGroup<CS> as Group>::Pk: serde::Deserialize<'de>, <KeGroup<CS> as \
+                       Group>::Sk: serde::Deserialize<'de>, SK: serde::Deserialize<'de>, OS: \
+                       serde::Deserialize<'de>",
+        serialize = "<KeGroup<CS> as Group>::Pk: serde::Serialize, <KeGroup<CS> as Group>::Sk: \
+                     serde::Serialize, SK: serde::Serialize, OS: serde::Serialize"
     ))
 )]
 #[derive_where(Clone)]
@@ -99,7 +102,10 @@ pub struct ClientRegistration<CS: CipherSuite> {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "")
+    serde(bound(
+        deserialize = "<KeGroup<CS> as Group>::Pk: serde::Deserialize<'de>",
+        serialize = "<KeGroup<CS> as Group>::Pk: serde::Serialize"
+    ))
 )]
 #[derive_where(Clone, ZeroizeOnDrop)]
 #[derive_where(Debug, Eq, Hash, Ord, PartialEq, PartialOrd; <KeGroup<CS> as Group>::Pk)]


### PR DESCRIPTION
Until now we had a manual Serde De/Serialization implementation for `Public/PrivateKey`. This PR changes that to shift the responsibility on the `Group` implementation. Now `Group` implementations can choose their own way to format their keys.

As `elliptic-curve` is the only implementation with dedicated types for non-identity elements and non-zero scalars, all other ones now require custom Serde implementations.

Resolves #300.
Based on #378.