### PR TITLE
Centralize block-size bounds and improve trait documentation

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -6,35 +6,65 @@
 // of this source tree. You may select, at your option, one of the above-listed
 // licenses.
 
-//! A convenience trait for digest bounds used throughout the library
+//! Convenience traits for digest bounds used throughout the library.
 
 use digest::block_buffer::Eager;
 use digest::core_api::{BlockSizeUser, BufferKindUser, CoreProxy, FixedOutputCore};
 use digest::{FixedOutputReset, HashMarker, OutputSizeUser};
 use generic_array::typenum::{IsLess, Le, NonZero, U256};
 
-pub(crate) type OutputSize<H> = <<H as CoreProxy>::Core as OutputSizeUser>::OutputSize;
+/// Output size of a hash function's core.
+pub(crate) type OutputSize<H> =
+    <<H as CoreProxy>::Core as OutputSizeUser>::OutputSize;
 
-/// Trait to simplify requirements for [`Hash`].
+/// Marker trait enforcing OPAQUE's supported hash block-size bounds.
+///
+/// This constraint applies to a hash function's internal block size
+/// (`BlockSizeUser::BlockSize`), not its digest output size.
+///
+/// Centralizing these bounds avoids repeating the same typenum constraints
+/// across multiple trait definitions and implementations.
+pub(crate) trait ValidBlockSize: BlockSizeUser
+where
+    <Self as BlockSizeUser>::BlockSize: IsLess<U256>,
+    Le<<Self as BlockSizeUser>::BlockSize, U256>: NonZero,
+{
+}
+
+impl<T: BlockSizeUser> ValidBlockSize for T
+where
+    <Self as BlockSizeUser>::BlockSize: IsLess<U256>,
+    Le<<Self as BlockSizeUser>::BlockSize, U256>: NonZero,
+{
+}
+
+/// Trait simplifying requirements for hash cores used by OPAQUE.
 pub trait ProxyHash:
-    HashMarker + FixedOutputCore + BufferKindUser<BufferKind = Eager> + Default + Clone
-where
-    <Self as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<Self as BlockSizeUser>::BlockSize, U256>: NonZero,
+    HashMarker
+    + FixedOutputCore
+    + BufferKindUser<BufferKind = Eager>
+    + Default
+    + Clone
+    + ValidBlockSize
 {
 }
 
-impl<T: HashMarker + FixedOutputCore + BufferKindUser<BufferKind = Eager> + Default + Clone>
-    ProxyHash for T
-where
-    <Self as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<Self as BlockSizeUser>::BlockSize, U256>: NonZero,
+impl<
+        T: HashMarker
+            + FixedOutputCore
+            + BufferKindUser<BufferKind = Eager>
+            + Default
+            + Clone
+            + ValidBlockSize,
+    > ProxyHash for T
 {
 }
 
-/// Trait inheriting the requirements from [`digest::Digest`] for compatibility
-/// with HKDF and HMAC Associated types could be simplified when they are made
-/// as defaults: <https://github.com/rust-lang/rust/issues/29661>
+/// Trait inheriting the requirements from [`digest::Digest`] for
+/// compatibility with HKDF and HMAC.
+///
+/// Associated types could be simplified when they are made defaults:
+/// <https://github.com/rust-lang/rust/issues/29661>
 pub trait Hash:
     Default
     + HashMarker
@@ -45,23 +75,19 @@ pub trait Hash:
     + Clone
 where
     <Self as CoreProxy>::Core: ProxyHash,
-    <<Self as CoreProxy>::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<<Self as CoreProxy>::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
 {
 }
 
 impl<
-    T: Default
-        + HashMarker
-        + OutputSizeUser<OutputSize = OutputSize<Self>>
-        + BlockSizeUser
-        + FixedOutputReset
-        + CoreProxy
-        + Clone,
-> Hash for T
+        T: Default
+            + HashMarker
+            + OutputSizeUser<OutputSize = OutputSize<Self>>
+            + BlockSizeUser
+            + FixedOutputReset
+            + CoreProxy
+            + Clone,
+    > Hash for T
 where
     <Self as CoreProxy>::Core: ProxyHash,
-    <<Self as CoreProxy>::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<<Self as CoreProxy>::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
 {
 }


### PR DESCRIPTION
## Summary

This PR introduces an internal `ValidBlockSize` marker trait and uses it to centralize the block-size constraints required by `ProxyHash` and `Hash`.

It also clarifies documentation by explicitly distinguishing a hash function's internal block size from its digest output size.

## Changes

* Add `pub(crate) trait ValidBlockSize`
* Add a blanket implementation for types satisfying the block-size requirements
* Replace duplicated typenum bounds in `ProxyHash` and `Hash`
* Improve documentation around block-size constraints and `OutputSize`

## Motivation

The same typenum constraints were repeated across multiple trait definitions and implementations:

```rust
<Self as BlockSizeUser>::BlockSize: IsLess<U256>,
Le<<Self as BlockSizeUser>::BlockSize, U256>: NonZero,
```

Centralizing these constraints:

* Reduces duplication
* Improves readability of trait signatures
* Provides a single source of truth for block-size requirements
* Simplifies future maintenance

The documentation updates also make it explicit that the constraint applies to a hash function's internal block size (`BlockSizeUser::BlockSize`) rather than its digest output size.

## Compatibility

This change is purely a refactor and documentation improvement. There are no functional, behavioral, or public API changes.
